### PR TITLE
Listc

### DIFF
--- a/text_reading/src/main/scala/org/clulab/aske/automates/entities/GrobidEntityFinder.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/entities/GrobidEntityFinder.scala
@@ -118,15 +118,11 @@ class GrobidEntityFinder(val grobidClient: GrobidQuantitiesClient, private var t
 
   def valueListToMentions(valueList: ValueList, doc: Document): Seq[Mention] = {
     val mentions = new ArrayBuffer[Mention]()
-    //var sentence: Int = -1
-    //val arguments = new scala.collection.mutable.HashMap[String, Seq[Mention]]
-    // Get the Mentions from each of the Quantities
+    // Get the Mentions from each of the Quantities in the value list; not doing anything with 'quantified'
     val values = valueList.values
     if (values.nonEmpty) {
       values.foreach(q => quantityToMentions(q.get, doc).foreach(m => mentions.append(m)))
-
     }
-
     mentions
   }
 

--- a/text_reading/src/main/scala/org/clulab/aske/automates/entities/GrobidEntityFinder.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/entities/GrobidEntityFinder.scala
@@ -118,15 +118,14 @@ class GrobidEntityFinder(val grobidClient: GrobidQuantitiesClient, private var t
 
   def valueListToMentions(valueList: ValueList, doc: Document): Seq[Mention] = {
     val mentions = new ArrayBuffer[Mention]()
-    var sentence: Int = -1
-    val arguments = new scala.collection.mutable.HashMap[String, Seq[Mention]]
+    //var sentence: Int = -1
+    //val arguments = new scala.collection.mutable.HashMap[String, Seq[Mention]]
     // Get the Mentions from each of the Quantities
     val values = valueList.values
     if (values.nonEmpty) {
       values.foreach(q => quantityToMentions(q.get, doc).foreach(m => mentions.append(m)))
 
     }
-
 
     mentions
   }

--- a/text_reading/src/main/scala/org/clulab/aske/automates/entities/GrobidEntityFinder.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/entities/GrobidEntityFinder.scala
@@ -33,6 +33,7 @@ class GrobidEntityFinder(val grobidClient: GrobidQuantitiesClient, private var t
     measurement match {
       case v: Value => valueToMentions(v, doc)
       case i: Interval => intervalToMentions(i, doc)
+      case vl: ValueList => valueListToMentions(vl, doc)
     }
   }
 
@@ -111,6 +112,21 @@ class GrobidEntityFinder(val grobidClient: GrobidQuantitiesClient, private var t
     val args = arguments.toMap
     val intervalMention = new RelationMention(getLabels(GrobidEntityFinder.INTERVAL_LABEL), mkTokenInterval(args), args, Map.empty, sentence, doc, keep = true, foundBy = GrobidEntityFinder.GROBID_FOUNDBY)
     mentions.append(intervalMention)
+
+    mentions
+  }
+
+  def valueListToMentions(valueList: ValueList, doc: Document): Seq[Mention] = {
+    val mentions = new ArrayBuffer[Mention]()
+    var sentence: Int = -1
+    val arguments = new scala.collection.mutable.HashMap[String, Seq[Mention]]
+    // Get the Mentions from each of the Quantities
+    val values = valueList.values
+    if (values.nonEmpty) {
+      values.foreach(q => quantityToMentions(q.get, doc).foreach(m => mentions.append(m)))
+
+    }
+
 
     mentions
   }

--- a/text_reading/src/main/scala/org/clulab/aske/automates/quantities/GrobidQuantitiesClient.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/quantities/GrobidQuantitiesClient.scala
@@ -49,8 +49,8 @@ class GrobidQuantitiesClient(
 
   def mkValueListFromListc(json: ujson.Js): ValueList = {
     val quantityList = json("quantities").arr.toList
-    quantityList.foreach(m => println(m + "\n"))
-    println("quant list" + quantityList)
+    //quantityList.foreach(m => println(m + "\n"))
+    //println("quant list" + quantityList)
     val values = for (quant <- quantityList) yield {Some(mkQuantity(quant))}
     val quantified = json.obj.get("quantified").map(mkQuantified)
 //    ValueList(values, quantified)

--- a/text_reading/src/main/scala/org/clulab/aske/automates/quantities/GrobidQuantitiesClient.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/quantities/GrobidQuantitiesClient.scala
@@ -28,6 +28,7 @@ class GrobidQuantitiesClient(
   def mkMeasurement(json: ujson.Js): Option[Measurement] = json("type").str match {
     case "value" => Some(mkValue(json))
     case "interval" => Some(mkInterval(json))
+    case "listc" => Some(mkValueListFromListc(json))
     //case t => throw new RuntimeException(s"unsupported measurement type '$t'")
     case t =>
       println(s"WARNING: there was an unsupported Measurement type ==> $t")
@@ -46,6 +47,17 @@ class GrobidQuantitiesClient(
     Interval(quantityLeast, quantityMost)
   }
 
+  def mkValueListFromListc(json: ujson.Js): ValueList = {
+    val quantityList = json("quantities").arr.toList
+    quantityList.foreach(m => println(m + "\n"))
+    println("quant list" + quantityList)
+    val values = for (quant <- quantityList) yield {Some(mkQuantity(quant))}
+    val quantified = json.obj.get("quantified").map(mkQuantified)
+//    ValueList(values, quantified)
+    ValueList(values, quantified)
+
+  }
+
   def mkQuantity(json: ujson.Js): Quantity = {
     val rawValue = json("rawValue").str
     val parsedValue = json("parsedValue")("numeric").num
@@ -55,6 +67,7 @@ class GrobidQuantitiesClient(
     val offset = mkOffset(json)
     Quantity(rawValue, parsedValue, normalizedValue, rawUnit, normalizedUnit, offset)
   }
+
 
   def mkUnit(json: ujson.Js): UnitOfMeasurement = {
     val name = json("name").str

--- a/text_reading/src/main/scala/org/clulab/aske/automates/quantities/Measurement.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/quantities/Measurement.scala
@@ -12,6 +12,11 @@ case class Interval(
   quantityMost: Option[Quantity]
 ) extends Measurement
 
+case class ValueList(
+  values: List[Some[Quantity]],
+  quantified: Option[Quantified]
+) extends Measurement
+
 case class Quantity(
   rawValue: String,
   parsedValue: Double,


### PR DESCRIPTION
This is supposed to handle type "listc" (a very very temporary fix), which is apparently a conjunctive list (https://github.com/kermitt2/grobid-quantities/blob/56bf7e13c48225539b07c5322a68cdd48e097a7a/src/main/java/org/grobid/core/utilities/UnitUtilities.java#L117)

If something is type listc, whatever is inside it is dealt with as atomic values (not intervals). This does not handle type listc as interval because grobid listc/interval output is not consistent. 

The before (a toy example):

![image](https://user-images.githubusercontent.com/31713912/53053669-4410cd00-345f-11e9-93cf-7048f065f0ac.png)

The after:

![image](https://user-images.githubusercontent.com/31713912/53053721-64408c00-345f-11e9-85ab-501a34173f21.png)

