### PR TITLE
Comment tests

### DIFF
--- a/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
+++ b/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
@@ -8,50 +8,8 @@ rules:
     label: Definition
     priority: ${priority}
     type: token
-    example: "TK4 is Temperature to 4th power ((oK)**4)"
+    example: "EEQ Equilibrium evaporation (mm/d)"
     #action: variableArguments
     pattern: |
-      @variable:Variable (?<Definition> [word = /.*/ & !word="-LRB-"]+)
+       @variable:Variable (?<definition> [word = /.*/ & !word="-LRB-"]+)
 
-#  - name: var_definition_appos
-#    label: Definition
-#    priority: ${priority}
-#    type: token
-#    example: "DSSAT-CSM employs the following formula for calculation of E0 (potential crop ET):"
-#    #action: variableArguments
-#    pattern: |
-#        @variable:Variable "-LRB-" @definition:Concept "-RRB-"
-#
-#  - name: var_definition_appos_bidir
-#    label: Definition
-#    priority: ${priority}
-#    type: token
-#    example: "DSSAT-CSM employs the following formula for calculation of E0 (potential crop ET):"
-#    #action: variableArguments
-#    action: selectShorterAsVariable
-#    pattern: |
-#      @c1:Concept "-LRB-" @c2:Concept  # "-RRB-"
-
-
-    #todo: with the next two rules, more tests fail
-#  - name: var_verb
-#    label: Definition
-#    priority: ${priority}
-#    type: dependency
-#    example: "The approach uses model-simulated LAI to calculate the Kcb. E0 is calculated as the product of Kcd and ETpm."
-#    pattern: |
-#      trigger = [word=/(?i)^calculat|defin/]
-#      variable:Concept+ = /${agents}/
-#      defintion: Concept = /nmod_as|nmod_by|nmod_with/
-#      #NB!Not good for "Crop coefficients (Kcs) are calculated for the current Penman-Monteith ET approach in DSSAT-CSM as:"
-#
-#  - name: var_cop_definition
-#    label: Definition
-#    priority: ${priority}
-#    type: dependency
-#    example: "The approach uses model-simulated LAI to calculate the Kcb. E0 is calculated as the product of Kcd and ETpm."
-#    pattern: |
-#      trigger = [lemma="be"]
-#      variable:Concept+ = <cop /${agents}/
-#      defintion: Concept = <cop
-#      #NB!Not good for "Crop coefficients (Kcs) are calculated for the current Penman-Monteith ET approach in DSSAT-CSM as:"

--- a/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
+++ b/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
@@ -8,10 +8,10 @@ rules:
     label: Definition
     priority: ${priority}
     type: token
-    example: "EORATIO is defined as the maximum Kcs at LAI = 6.0"
+    example: "TK4 is Temperature to 4th power ((oK)**4)"
     #action: variableArguments
     pattern: |
-      @variable:Variable ( is| is defined as) (an|a|the) @definition:Concept
+      @variable:Variable is (?<Definition> /.*/)
 
 #  - name: var_definition_appos
 #    label: Definition
@@ -21,16 +21,16 @@ rules:
 #    #action: variableArguments
 #    pattern: |
 #        @variable:Variable "-LRB-" @definition:Concept "-RRB-"
-
-  - name: var_definition_appos_bidir
-    label: Definition
-    priority: ${priority}
-    type: token
-    example: "DSSAT-CSM employs the following formula for calculation of E0 (potential crop ET):"
-    #action: variableArguments
-    action: selectShorterAsVariable
-    pattern: |
-      @c1:Concept "-LRB-" @c2:Concept  # "-RRB-"
+#
+#  - name: var_definition_appos_bidir
+#    label: Definition
+#    priority: ${priority}
+#    type: token
+#    example: "DSSAT-CSM employs the following formula for calculation of E0 (potential crop ET):"
+#    #action: variableArguments
+#    action: selectShorterAsVariable
+#    pattern: |
+#      @c1:Concept "-LRB-" @c2:Concept  # "-RRB-"
 
 
     #todo: with the next two rules, more tests fail

--- a/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
+++ b/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
@@ -4,14 +4,14 @@ rules:
 
 ####DEFINITIONS####
 
-  - name: var_is_definition
+  - name: var_definition
     label: Definition
     priority: ${priority}
     type: token
     example: "TK4 is Temperature to 4th power ((oK)**4)"
     #action: variableArguments
     pattern: |
-      @variable:Variable is (?<Definition> /.*/)
+      @variable:Variable (?<Definition> [word = /.*/ & !word="-LRB-"]+)
 
 #  - name: var_definition_appos
 #    label: Definition

--- a/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/entities.yml
+++ b/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/entities.yml
@@ -1,0 +1,15 @@
+vars: org/clulab/aske_automates/grammars/vars.yml
+
+rules:
+
+
+
+####VARIABLES####
+
+  - name: var_is_defined
+    label: Variable
+    priority: 1
+    type: token
+    example: "E0 is calculated as the product of Kcd and ETpm."
+    pattern: |
+      ^[chunk="B-NP" & !tag="CD"]

--- a/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/master.yml
+++ b/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/master.yml
@@ -5,14 +5,14 @@ vars: "org/clulab/aske_automates/grammars/triggers.yml"
 rules:
 
 
-  - import: "org/clulab/aske_automates/grammars/entities.yml"
+  - import: "org/clulab/aske_automates/grammars/comments/entities.yml"
     vars:
       priority: 1
 
 #  - import: "org/clulab/aske_automates/grammars/intervalVariables.yml"
 #    vars:
 #      priority: 2
-
+#
   - import: "org/clulab/aske_automates/grammars/comments/definitions.yml"
     vars:
       priority: 3

--- a/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/master.yml
+++ b/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/master.yml
@@ -15,7 +15,7 @@ rules:
 #
   - import: "org/clulab/aske_automates/grammars/comments/definitions.yml"
     vars:
-      priority: 3
+      priority: 2
 
 #  - import: "org/clulab/aske_automates/grammars/parameterSettings.yml"
 #    vars:

--- a/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
@@ -76,9 +76,9 @@ class OdinEngine(
 
   def extractFrom(doc: Document): Vector[Mention] = {
     // Add any mentions from the entityFinders to the initial state
-    if (entityFinders.nonEmpty) {
-      println("Using EFs")
-      initialState = initialState.updated(entityFinders.flatMap(ef => ef.extract(doc)))
+    val initialState = entityFinders match {
+      case Seq() => new State()
+      case _ => State(entityFinders.flatMap(ef => ef.extract(doc)))
     }
 //     println(s"In extractFrom() -- res : ${initialState.allMentions.map(m => m.text).mkString(",\t")}")
 

--- a/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
@@ -76,9 +76,9 @@ class OdinEngine(
 
   def extractFrom(doc: Document): Vector[Mention] = {
     // Add any mentions from the entityFinders to the initial state
-    val initialState = entityFinders match {
-      case Seq() => new State()
-      case _ => State(entityFinders.flatMap(ef => ef.extract(doc)))
+    if (entityFinders.nonEmpty) {
+      println("Using EFs")
+      initialState = initialState.updated(entityFinders.flatMap(ef => ef.extract(doc)))
     }
 //     println(s"In extractFrom() -- res : ${initialState.allMentions.map(m => m.text).mkString(",\t")}")
 

--- a/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
@@ -105,7 +105,7 @@ object ExtractAndAlign {
       println(s"Extracting from ${file.getName}")
       // Get the input file contents, note: for science parse format, each text is a section
       val texts = dataLoader.loadFile(file)
-      println("TEXTS: " + texts.length)
+      //println("TEXTS: " + texts.length)
       // Parse the comment texts
       // todo!!
       val docs = texts.map(parseCommentText(_, filename = Some(file.getName)))
@@ -117,9 +117,9 @@ object ExtractAndAlign {
         // Reset the odin initial state with the found GrFN variables
         _ = commentReader.resetInitialState(foundGrFNVars)
       } yield commentReader.extractFrom(doc)
-      for (m <- mentions) {
-        println("-->", m.mkString(" "))
-      }
+//      for (m <- mentions) {
+//        println("-->", m.mkString(" "))
+//      }
 
       mentions.flatten
     }

--- a/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
@@ -117,6 +117,9 @@ object ExtractAndAlign {
         // Reset the odin initial state with the found GrFN variables
         _ = commentReader.resetInitialState(foundGrFNVars)
       } yield commentReader.extractFrom(doc)
+      for (m <- mentions) {
+        println("-->", m.mkString(" "))
+      }
 
       mentions.flatten
     }

--- a/text_reading/src/test/resources/test.conf
+++ b/text_reading/src/test/resources/test.conf
@@ -28,3 +28,17 @@ TextEngine {
 
 }
 
+CommentEngine {
+  //  basePath = /org/clulab/aske_automates
+  masterRulesPath = ${TextEngine.basePath}/grammars/comments/master.yml
+  taxonomyPath = ${TextEngine.taxonomyPath}
+
+  enableLexiconNER = false
+  enableExpansion = false
+  documentFilter = "length"
+
+  entityFinder {
+    enabled = false
+  }
+}
+

--- a/text_reading/src/test/scala/org/clulab/aske/automates/TestUtils.scala
+++ b/text_reading/src/test/scala/org/clulab/aske/automates/TestUtils.scala
@@ -30,7 +30,10 @@ object TestUtils {
   protected var mostRecentConfig: Option[Config] = None
 
   // This is the standard way to extract mentions for testing
-  def extractMentions(ieSystem: OdinEngine, text: String): Seq[Mention] = ieSystem.extractFromText(text, true, None)
+  def extractMentions(ieSystem: OdinEngine, text: String): Seq[Mention] = {
+    ieSystem.resetInitialState(Seq.empty)
+    ieSystem.extractFromText(text, true, None)
+  }
 
   def newOdinSystem(config: Config): OdinEngine = this.synchronized {
     val readingSystem =

--- a/text_reading/src/test/scala/org/clulab/aske/automates/TestUtils.scala
+++ b/text_reading/src/test/scala/org/clulab/aske/automates/TestUtils.scala
@@ -120,4 +120,74 @@ object TestUtils {
 
   }
 
+  class ExtractionFromCommentsTest(val ieSystem: OdinEngine) extends Test {
+    def this(config: Config = ConfigFactory.load("test")) = this(newOdinSystem(config[Config]("CommentEngine")))
+
+    def extractMentions(text: String): Seq[Mention] = TestUtils.extractMentions(ieSystem, text)
+
+    // Event Specific
+
+    def testDefinitionEvent(mentions: Seq[Mention], desired: Seq[(String, Seq[String])]): Unit = {
+      testBinaryEvent(mentions, DEFINITION_LABEL, VARIABLE_ARG, DEFINITION_ARG, desired)
+    }
+
+    def testParameterSettingEvent(mentions: Seq[Mention], desired: Seq[(String, Seq[String])]): Unit = {
+      testBinaryEvent(mentions, PARAMETER_SETTING_LABEL, VARIABLE_ARG, VALUE_ARG, desired)
+    }
+
+    def testParameterSettingEventInterval(mentions: Seq[Mention], desired: Seq[Seq[String]]): Unit = {
+      testThreeArgEvent(mentions, INTERVAL_PARAMETER_SETTING_LABEL, VARIABLE_ARG, VALUE_LEAST_ARG, VALUE_MOST_ARG, desired)
+    }
+
+    // General Purpose
+
+    def testTextBoundMention(mentions: Seq[Mention], eventType: String, desired: Seq[String]): Unit = {
+      val found = mentions.filter(_ matches eventType).map(_.text)
+      found.length should be(desired.size)
+
+      desired.foreach(d => found should contain(d))
+    }
+
+
+    def testThreeArgEvent(mentions: Seq[Mention], eventType: String, arg1Role: String, arg2Role: String, arg3Role: String, desired: Seq[Seq[String]]): Unit = {
+      val found = mentions.filter(_ matches eventType)
+      found.length should be(desired.size)
+
+    }
+
+    def testBinaryEvent(mentions: Seq[Mention], eventType: String, arg1Role: String, arg2Role: String, desired: Seq[(String, Seq[String])]): Unit = {
+      val found = mentions.filter(_ matches eventType)
+      found.length should be(desired.size)
+
+
+      val grouped = found.groupBy(_.arguments(arg1Role).head.text) // we assume only one variable (arg1) arg!
+      for {
+        (desiredVar, desiredDefs) <- desired
+        correspondingMentions = grouped.getOrElse(desiredVar, Seq())
+      } testBinaryEventStrings(correspondingMentions, arg1Role, desiredVar, arg2Role, desiredDefs)
+    }
+
+
+    def testBinaryEventStrings(ms: Seq[Mention], arg1Role: String, arg1String: String, arg2Role: String, arg2Strings: Seq[String]) = {
+      val variableDefinitionPairs = for {
+        m <- ms
+        a1 <- m.arguments.getOrElse(arg1Role, Seq()).map(_.text)
+        a2 <- m.arguments.getOrElse(arg2Role, Seq()).map(_.text)
+      } yield (a1, a2)
+
+      arg2Strings.foreach(arg2String => variableDefinitionPairs should contain ((arg1String, arg2String)))
+    }
+
+    def mentionHasArguments(m: Mention, argName: String, argValues: Seq[String]): Unit = {
+      // Check that the desired number of that argument were found
+      val selectedArgs = m.arguments.getOrElse(argName, Seq())
+      selectedArgs should have length(argValues.length)
+
+      // Check that each of the arg values is found
+      val argStrings = selectedArgs.map(_.text)
+      argValues.foreach(argStrings should contain (_))
+    }
+
+  }
+
 }

--- a/text_reading/src/test/scala/org/clulab/aske/automates/TestUtils.scala
+++ b/text_reading/src/test/scala/org/clulab/aske/automates/TestUtils.scala
@@ -82,7 +82,7 @@ object TestUtils {
     def testThreeArgEvent(mentions: Seq[Mention], eventType: String, arg1Role: String, arg2Role: String, arg3Role: String, desired: Seq[Seq[String]]): Unit = {
       val found = mentions.filter(_ matches eventType)
       found.length should be(desired.size)
-
+      //todo add func to check args and not only the size
     }
 
     def testBinaryEvent(mentions: Seq[Mention], eventType: String, arg1Role: String, arg2Role: String, desired: Seq[(String, Seq[String])]): Unit = {

--- a/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentDefinitions.scala
+++ b/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentDefinitions.scala
@@ -5,27 +5,21 @@ import org.clulab.aske.automates.TestUtils._
 class TestCommentDefinitions extends ExtractionFromCommentsTest {
 
 
-  val t1a = "EEQ equilibrium evaporation (mm/d)"
+  val t1a = "EEQ Equilibrium evaporation (mm/d)"
   passingTest should s"extract definitions from t1a: ${t1a}" taggedAs(Somebody) in {
     val desired = Seq(
-      "EEQ" -> Seq("equilibrium evaporation")
+      "EEQ" -> Seq("Equilibrium evaporation")
     )
     val mentions = extractMentions(t1a)
-    for (m <- mentions) {
-      println("--> " + m.text + " " + "Label: " + m.label )
-    }
     testDefinitionEvent(mentions, desired)
   }
 
-  val t2a = "S rate of change of saturated vapor pressure of air with temperature (Pa/K)"
+  val t2a = "S Rate of change of saturated vapor pressure of air with temperature (Pa/K)"
   passingTest should s"extract definitions from t1a: ${t2a}" taggedAs(Somebody) in {
     val desired = Seq(
-      "S" -> Seq("rate of change of saturated vapor pressure of air with temperature")
+      "S" -> Seq("Rate of change of saturated vapor pressure of air with temperature")
     )
     val mentions = extractMentions(t2a)
-    for (m <- mentions) {
-      println("--> " + m.text + " " + m.label)
-    }
     testDefinitionEvent(mentions, desired)
   }
 

--- a/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentDefinitions.scala
+++ b/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentDefinitions.scala
@@ -2,7 +2,7 @@ package org.clulab.aske.automates.text
 
 import org.clulab.aske.automates.TestUtils._
 
-class TestCommentDefinitions extends ExtractionTest {
+class TestCommentDefinitions extends ExtractionFromCommentsTest {
 
 
   val t1a = "EEQ is equilibrium evaporation (mm/d)"
@@ -11,15 +11,21 @@ class TestCommentDefinitions extends ExtractionTest {
       "EEQ" -> Seq("equilibrium evaporation")
     )
     val mentions = extractMentions(t1a)
+    for (m <- mentions) {
+      println("--> " + m.text + " " + m.label )
+    }
     testDefinitionEvent(mentions, desired)
   }
 
-  val t2a = "S is the rate of change of saturated vapor pressure of air with           temperature (Pa/K)"
+  val t2a = "S is the rate of change of saturated vapor pressure of air with temperature (Pa/K)"
   passingTest should s"extract definitions from t1a: ${t2a}" taggedAs(Somebody) in {
     val desired = Seq(
-      "EEQ" -> Seq("rate of change of saturated vapor pressure of air with           temperature")
+      "S" -> Seq("rate of change of saturated vapor pressure of air with temperature")
     )
     val mentions = extractMentions(t2a)
+    for (m <- mentions) {
+      println("--> " + m.text + " " + m.label)
+    }
     testDefinitionEvent(mentions, desired)
   }
 

--- a/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentDefinitions.scala
+++ b/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentDefinitions.scala
@@ -5,19 +5,19 @@ import org.clulab.aske.automates.TestUtils._
 class TestCommentDefinitions extends ExtractionFromCommentsTest {
 
 
-  val t1a = "EEQ is equilibrium evaporation (mm/d)"
+  val t1a = "EEQ equilibrium evaporation (mm/d)"
   passingTest should s"extract definitions from t1a: ${t1a}" taggedAs(Somebody) in {
     val desired = Seq(
       "EEQ" -> Seq("equilibrium evaporation")
     )
     val mentions = extractMentions(t1a)
     for (m <- mentions) {
-      println("--> " + m.text + " " + m.label )
+      println("--> " + m.text + " " + "Label: " + m.label )
     }
     testDefinitionEvent(mentions, desired)
   }
 
-  val t2a = "S is the rate of change of saturated vapor pressure of air with temperature (Pa/K)"
+  val t2a = "S rate of change of saturated vapor pressure of air with temperature (Pa/K)"
   passingTest should s"extract definitions from t1a: ${t2a}" taggedAs(Somebody) in {
     val desired = Seq(
       "S" -> Seq("rate of change of saturated vapor pressure of air with temperature")

--- a/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentVariables.scala
+++ b/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentVariables.scala
@@ -11,9 +11,6 @@ class TestCommentVariables extends ExtractionFromCommentsTest {
 
     val desired = Seq("EEQ")
     val mentions = extractMentions(t1)
-    for (m <- mentions) {
-      println("--> " + m.text + " " + m.label)
-    }
     testTextBoundMention(mentions, VARIABLE_LABEL, desired)
   }
 
@@ -24,9 +21,6 @@ class TestCommentVariables extends ExtractionFromCommentsTest {
 
     val desired = Seq()  // this is from revision history; do we eliminate these in preprocessing? Can probably make a neg lookbehind for date format? but can keep the test in case it gets in as a sentence
     val mentions = extractMentions(t2)
-    for (m <- mentions) {
-      println("--> " + m.text + " " + m.label)
-    }
     testTextBoundMention(mentions, VARIABLE_LABEL, desired)
   }
 

--- a/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentVariables.scala
+++ b/text_reading/src/test/scala/org/clulab/aske/automates/text/TestCommentVariables.scala
@@ -3,7 +3,7 @@ package org.clulab.aske.automates.text
 import org.clulab.aske.automates.OdinEngine.VARIABLE_LABEL
 import org.clulab.aske.automates.TestUtils._
 
-class TestCommentVariables extends ExtractionTest {
+class TestCommentVariables extends ExtractionFromCommentsTest {
 
   val t1 = "EEQ is equilibrium evaporation (mm/d)"
   passingTest should s"extract variables from t1: ${t1}" taggedAs(Somebody) in {
@@ -11,6 +11,9 @@ class TestCommentVariables extends ExtractionTest {
 
     val desired = Seq("EEQ")
     val mentions = extractMentions(t1)
+    for (m <- mentions) {
+      println("--> " + m.text + " " + m.label)
+    }
     testTextBoundMention(mentions, VARIABLE_LABEL, desired)
   }
 
@@ -21,6 +24,9 @@ class TestCommentVariables extends ExtractionTest {
 
     val desired = Seq()  // this is from revision history; do we eliminate these in preprocessing? Can probably make a neg lookbehind for date format? but can keep the test in case it gets in as a sentence
     val mentions = extractMentions(t2)
+    for (m <- mentions) {
+      println("--> " + m.text + " " + m.label)
+    }
     testTextBoundMention(mentions, VARIABLE_LABEL, desired)
   }
 


### PR DESCRIPTION
- went back on this change from the previous PR because it looks like that broke several tests:
https://github.com/ml4ai/automates/blob/4214b0dbf8078a4fbb78f9c38a3142b51bc201d8/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala#L79
- made changes to have comment tests use CommentEngine and not TestEngine;
- wrote a rule to extract vars and definitions from comments---the var tests pass, but not definition ones although the mentions as printed out from within the comment definition tests seem to look right; haven't figured out why the tests fail yet (upd: found the error in the rule that caused the tests to break);
- changed the comment tests not to include 'is' (we don't insert 'is' in preprocessing, so neither the rules, nor the tests will contain it);
- added a todo that forgot to add a while ago.