### PR TITLE
grammar updates

### DIFF
--- a/text_reading/src/main/resources/application.conf
+++ b/text_reading/src/main/resources/application.conf
@@ -47,8 +47,8 @@ CommentEngine {
 
   entityFinder {
     enabled = true
-    finderTypes = ["grfn"]
-
+    finderTypes = ["grfn", "gazetteer"]
+    lexicons = ${TextEngine.entityFinder.lexicons}
     // GrFN-based string match
     grfnFile = ${apps.grfnFile}
 

--- a/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
+++ b/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
@@ -9,8 +9,7 @@ rules:
     priority: ${priority}
     type: token
     example: "EEQ Equilibrium evaporation (mm/d)"
-#    action: looksLikeAVariable #don't use this action here---the illegal "vars" should have been
-    #filtered out in the entity rule
+    action: looksLikeAVariable
     pattern: |
-       @variable:Variable (?<definition> [word = /.*/ & !tag="-LRB-"]+)
+       @variable:Variable (?<definition> [word = /.*/ & !tag="-LRB-"]+) | (@variable:Variable [entity = "B-GreekLetter"]) (?<definition> [word = /.*/ & !tag="-LRB-"]+)
 


### PR DESCRIPTION
Updates to conf and a rule.
This seems to eliminate false positives introduced by fixing GrFNEntityFinder in this commit https://github.com/ml4ai/automates/commit/0be3b28b7ed7db4ee88ce4f4550f64f763b1cd37

I am still not sure why that fix resulted in false positives, but these changes seem to bring the extractions closer to what they were before + another variable is extracted correctly from the comments (a greek letter one). 