### PR TITLE
toggling boxes per annotation entity type

### DIFF
--- a/pdfalign/pdfalign.py
+++ b/pdfalign/pdfalign.py
@@ -877,21 +877,25 @@ class PdfAlign(Frame):
     def select_equation(self):
         if self.active_annotation is not None:
             self.annotation_mode = 'equation'
+            self.token_mode = False
             self.redraw()
 
     def select_text(self):
         if self.active_annotation is not None:
             self.annotation_mode = 'text'
+            self.token_mode = True
             self.redraw()
 
     def select_description(self):
         if self.active_annotation is not None:
             self.annotation_mode = 'description'
+            self.token_mode = True
             self.redraw()
 
     def select_unit(self):
         if self.active_annotation is not None:
             self.annotation_mode = 'unit'
+            self.token_mode = True
             self.redraw()
 
     def add_component(self):


### PR DESCRIPTION
This seems to address @adarshp's suggestion that @cl4yton mentioned in his email---by default, the boxes will be character-based for in-equation variables and token-based for everything else. Let me know if that doesn't work. 
Please still try to make sure to switch to characters in cases where the token-level box happens to include punctuation. 