### PR TITLE
Speed and ergonomics improvements in pdfalign

### DIFF
--- a/pdfalign/README.md
+++ b/pdfalign/README.md
@@ -6,7 +6,7 @@
     conda activate pdfalign
 
     conda install lxml pillow chardet pycryptodome sortedcontainers six poppler texlive-core --yes
-    pip install webcolors pdf2image
+    pip install webcolors pdf2image tqdm
 
     # install the ml4ai fork of pdfminer
     pip install -e git+https://github.com/ml4ai/pdfminer.six.git#egg=pdfminer.six
@@ -95,7 +95,7 @@ methods below.
 
 You can either just get the `pdfalign` script and its dependencies using 
   
-    pip install lxml webcolors pdf2image
+    pip install lxml webcolors pdf2image tqdm
     curl -O https://raw.githubusercontent.com/ml4ai/automates/master/pdfalign/pdfalign.py
 
 Then, launch it with:

--- a/pdfalign/pdfalign.py
+++ b/pdfalign/pdfalign.py
@@ -655,7 +655,7 @@ class PdfAlign(Frame):
             command=self.new_annotation,
         ).pack(side=LEFT)
         Button(
-            toolbar, text="Add component (c)", command=self.add_component
+            toolbar, text="Add component (a)", command=self.add_component
         ).pack(side=LEFT)
         self.in_equation_rb = Radiobutton(
             toolbar,

--- a/pdfalign/pdfalign.py
+++ b/pdfalign/pdfalign.py
@@ -266,7 +266,7 @@ class AABBTree:
         return collisions
 
     def contains(self, point):
-        """return AABBs that contain a given point"""
+        """Return AABBs that contain a given point"""
 
         def detect_collision(node):
             return node.aabb.contains(point)
@@ -274,7 +274,7 @@ class AABBTree:
         return self.get_collisions(detect_collision)
 
     def intersects(self, aabb):
-        """return AABBs that intersect a given AABB"""
+        """Return AABBs that intersect a given AABB"""
 
         def detect_collision(node):
             return node.aabb.intersects(aabb)
@@ -283,7 +283,7 @@ class AABBTree:
 
 
 def split_pages(filename):
-    print("Separating pages for file {}".format(filename))
+    print(f"Separating pages for file {filename}")
     dirname = os.path.dirname(filename)
     page_pattern = os.path.join(dirname, "page-%03d.pdf")
     command = ["pdfseparate", filename, page_pattern]
@@ -597,19 +597,20 @@ class PdfAlign(Frame):
         self.charid = 0
         self.page_boxes = dict(token=[], char=[])
         self.aabb_trees = None
-        # the bounding box around the equation to be annotated
+        # The bounding box around the equation to be annotated
         self.annotation_aabb = None
-        # holder to display the transparent rectangles
+        # Holder to display the transparent rectangles
         self.rectangles = []
-        # history
+        # History
         self.history_boxes = []
-        # the lookup for the token that corresponds to the bounding box
+        # The lookup for the token that corresponds to the bounding box
         self.all_tokens = []
         self.char_token_lut = dict()
         self.token_char_lut = defaultdict(list)
 
         # The properties/attributes of the tool itself
-        # annotation colors
+
+        # Annotation colors
         self.annotation_mode = "equation"
         self.active_annotation = None
         self.token_mode = True
@@ -618,15 +619,17 @@ class PdfAlign(Frame):
 
         toolbar = Frame(self)
         Button(toolbar, text="Open (o)", command=self.open).pack(side=LEFT)
-        Button(toolbar, text="Import (i)", command=self.import_annotations).pack(
-            side=LEFT
-        )
-        Button(toolbar, text="◀", command=self.prev).pack(
-            side=LEFT
-        )
+        Button(
+            toolbar, text="Import (i)", command=self.import_annotations
+        ).pack(side=LEFT)
+        Button(toolbar, text="◀", command=self.prev).pack(side=LEFT)
         Button(toolbar, text="▶", command=self.next).pack(side=LEFT)
-        Button(toolbar, text="Zoom in (+)", command=self.zoom_in).pack(side=LEFT)
-        Button(toolbar, text="Zoom out (-)", command=self.zoom_out).pack(side=LEFT)
+        Button(toolbar, text="Zoom in (+)", command=self.zoom_in).pack(
+            side=LEFT
+        )
+        Button(toolbar, text="Zoom out (-)", command=self.zoom_out).pack(
+            side=LEFT
+        )
         ttk.Label(toolbar, textvariable=self.num_page_tv).pack(side=LEFT)
 
         ttk.Label(toolbar, text="Token mode (k)").pack(side=LEFT)
@@ -648,11 +651,13 @@ class PdfAlign(Frame):
         self.token_mode_off_rb.pack(side=LEFT)
 
         Button(
-            toolbar, text="Annotate new variable (n)", command=self.new_annotation
+            toolbar,
+            text="Annotate new variable (n)",
+            command=self.new_annotation,
         ).pack(side=LEFT)
-        Button(toolbar, text="Add component (c)", command=self.add_component).pack(
-            side=LEFT
-        )
+        Button(
+            toolbar, text="Add component (c)", command=self.add_component
+        ).pack(side=LEFT)
         self.in_equation_rb = Radiobutton(
             toolbar,
             text="In equation (e)",
@@ -692,10 +697,12 @@ class PdfAlign(Frame):
         Button(toolbar, text="Save (s)", command=self.save_annotation).pack(
             side=LEFT
         )
-        Button(toolbar, text="Export (x)", command=self.export_annotations).pack(
+        Button(
+            toolbar, text="Export (x)", command=self.export_annotations
+        ).pack(side=LEFT)
+        Button(toolbar, text="Quit (q)", command=self.client_exit).pack(
             side=LEFT
         )
-        Button(toolbar, text="Quit (q)", command=self.client_exit).pack(side=LEFT)
         toolbar.pack(side=TOP, fill=BOTH)
 
         # Keyboard shortcuts
@@ -1126,26 +1133,13 @@ class PdfAlign(Frame):
 
     def click(self, event):
         canvas = event.widget
-        # normalize coordinates
+        # Normalize coordinates
         x = canvas.canvasx(event.x) / self.scale / self.dpi
         y = canvas.canvasy(event.y) / self.scale / self.dpi
-        # query synctex
+        # Query synctex
         result = synctex(self.num_page, x, y, self.filename)
 
-        # display synctex results
-        # with open(result['input']) as f:
-        #     text = f.read()
-        #     self.text.focus()
-        #     # set text
-        #     self.text.delete(1.0, END)
-        #     self.text.insert(1.0, text)
-        #     # select line
-        #     self.text.see(f"{result['line']}.0")
-        #     self.text.mark_set('insert', f"{result['line']}.0")
-        #     self.text.tag_remove('highlight', 1.0, 'end')
-        #     self.text.tag_add('highlight', f"{result['line']}.0", f"{result['line']}.end+1c")
-
-        # get annotation
+        # Get annotation
         if self.active_annotation and self.annotation_mode:
             tree = self.aabb_trees[self.box_mode()][self.num_page]
             collisions = tree.contains(Point(x, y))
@@ -1511,28 +1505,6 @@ class PdfAlign(Frame):
     # NOTE pdftotext -bbox-layout returns the bounding boxes of the first page only
     # so we need to split the paper into pages and call this for each page
 
-    # def iter_token_bboxes(self, filename, page):
-    #     dpi = 72  # educated guess
-    #     command = ['pdftotext', '-bbox-layout', filename, '-']
-    #     result = subprocess.run(command, capture_output=True)
-    #     namespaces = dict(html='http://www.w3.org/1999/xhtml')
-    #     x = remove_bad_chars(result.stdout)
-    #     tree = etree.fromstring(x)
-    #     # .//text
-    #     for node in tree.findall('.//html:word', namespaces=namespaces):
-    #         text = node.text
-    #         # node.attrib['bbox'] -- split etc
-    #         xmin = float(node.attrib['xMin']) / dpi
-    #         ymin = float(node.attrib['yMin']) / dpi
-    #         xmax = float(node.attrib['xMax']) / dpi
-    #         ymax = float(node.attrib['yMax']) / dpi
-    #         aabb = AABB(xmin, ymin, xmax, ymax)
-    #         # just attach metadata
-    #         aabb.value = text
-    #         aabb.page = page
-    #         yield aabb
-
-    # make this not an iterator and return the char and token aabbs
     def populate_page_bboxes(self, filename, page):
         dpi = 72  # educated guess
         command = ["pdf2txt.py", "-t", "xml", filename]
@@ -1552,7 +1524,7 @@ class PdfAlign(Frame):
             if text is not None:
                 if len(text.strip()) == 0:
                     if curr_token_aabb is not None:
-                        # the current token ended
+                        # The current token ended
                         curr_token_aabb.page = page
                         curr_token_aabb.id = len(self.all_tokens)
                         self.all_tokens.append(curr_token_aabb)
@@ -1564,7 +1536,7 @@ class PdfAlign(Frame):
                     bbox = node.attrib.get("bbox")
                     if bbox is not None:
                         # The bboxes from pdf2txt are a little diff:
-                        # per https: // github.com / euske / pdfminer / issues / 171
+                        # per https://github.com/euske/pdfminer/issues/171
                         # The bbox value is (x0,y0,x1,y1).
                         # x0: the distance from the left of the page to the left edge of the box.
                         # y0: the distance from the bottom of the page to the lower edge of the box.
@@ -1577,7 +1549,7 @@ class PdfAlign(Frame):
                         xmax = float(xmax) / dpi
                         ymax = (-1 * float(ymax) + page_height) / dpi
                         aabb = AABB(xmin, ymin, xmax, ymax)
-                        # store metadata
+                        # Store metadata
                         aabb.value = text
                         aabb.page = page
                         aabb.font = node.attrib.get("font")
@@ -1596,10 +1568,10 @@ class PdfAlign(Frame):
                         # Update the bbox luts
                         self.char_token_lut[aabb] = aabb.tokenid
                         self.token_char_lut[aabb.tokenid].append(aabb)
-                        # add the current box
+                        # Add the current box
                         char_boxes.append(aabb)
-        self.page_boxes["token"].append(token_boxes)
-        self.page_boxes["char"].append(char_boxes)
+        self.page_boxes["token"].append(sorted(token_boxes, key=lambda x: x.area))
+        self.page_boxes["char"].append(sorted(char_boxes, key=lambda x: x.area))
 
     def populate_bboxes(self, filename):
         for i, p in enumerate(
@@ -1620,7 +1592,7 @@ class PdfAlign(Frame):
             AABBTree.from_boxes(page)
             for page in tqdm(
                 page_boxes[box_type],
-                desc="Making binary trees from {} boxes".format(box_type),
+                desc=f"Making binary trees from {box_type} boxes",
                 unit="page",
                 ncols=80,
             )

--- a/pdfalign/pdfalign.py
+++ b/pdfalign/pdfalign.py
@@ -69,21 +69,24 @@ class Point:
 
 class AABB:
     def __init__(self, xmin, ymin, xmax, ymax):
-        # position
+        # Position
         self.xmin = xmin
         self.ymin = ymin
         self.xmax = xmax
         self.ymax = ymax
         self.area = self.width * self.height
         self.id = None
-        # content
+
+        # Content
         self.value = None
         self.font = None
         self.font_size = None
-        # the corresponding token from pdfminer lines
+
+        # The corresponding token from pdfminer lines
         self.token = None
         self.tokenid = None
-        # synctex
+
+        # Synctex
         self.synctex = None
 
     def __repr__(self):
@@ -111,10 +114,6 @@ class AABB:
     @property
     def perimeter(self):
         return 2 * (self.width + self.height)
-
-    # @property
-    # def area(self):
-    #     return self.width * self.height
 
     def contains(self, point):
         return (
@@ -201,7 +200,7 @@ class AABBTree:
 
     @property
     def depth(self):
-        """returns the tree depth"""
+        """Returns the tree depth"""
         # FIXME this is inefficient, don't compute it on-the-fly
         if self.is_leaf:
             return 0
@@ -213,73 +212,43 @@ class AABBTree:
         if self.is_empty:
             self.aabb = aabb
         elif self.is_leaf:
-            # set children
+            # Set children
             self.left = deepcopy(self)
             self.right = AABBTree(aabb)
-            # set fat aabb
+            # Set fat aabb
             self.aabb = AABB.merge(self.left.aabb, self.right.aabb)
         else:
-            # merged AABBs
-            # hypothetical area instead
+            # Merged AABBs
+            # Hypothetical area instead
             merged_self = AABB.merge(aabb, self.aabb)
             merged_left = AABB.merge(aabb, self.left.aabb)
             merged_right = AABB.merge(aabb, self.right.aabb)
-            # cost of creating a new parent for this node and the new leaf
+            # Cost of creating a new parent for this node and the new leaf
             self_cost = 2 * merged_self.area
-            # minimum cost of pushing the leaf further down the tree
+            # Minimum cost of pushing the leaf further down the tree
             inheritance_cost = 2 * (merged_self.area - self.aabb.area)
-            # cost of descending left
+            # Cost of descending left
             left_cost = (
                 merged_left.area - self.left.aabb.area + inheritance_cost
             )
-            # cost of descending right
+            # Cost of descending right
             right_cost = (
                 merged_right.area - self.right.aabb.area + inheritance_cost
             )
-            # descend
+            # Descend
             if self_cost < left_cost and self_cost < right_cost:
-                # set children
+                # Set children
                 self.left = deepcopy(self)
                 self.right = AABBTree(aabb)
             elif left_cost < right_cost:
                 self.left.add(aabb)
             else:
                 self.right.add(aabb)
-            # set fat aabb
+            # Set fat aabb
             self.aabb = AABB.merge(self.left.aabb, self.right.aabb)
 
-    #     def balance(self):
-    #         """balance binary tree"""
-    #         if self.is_leaf:
-    #             return
-    #         # balance children
-    #         self.left.balance()
-    #         self.right.balance()
-    #         # balance self
-    #         diff = self.left.depth - self.right.depth
-    #         while abs(diff) > 1:
-    #             root = deepcopy(self)
-    #             # rotate
-    #             if diff > 1:
-    #                 pivot = self.left
-    #                 root.left = pivot.right
-    #                 pivot.right = root
-    #             elif diff < -1:
-    #                 pivot = self.right
-    #                 root.right = pivot.left
-    #                 pivot.left = root
-    #             # update fat AABBs (order is important)
-    #             root.aabb = AABB.merge(root.left.aabb, root.right.aabb)
-    #             pivot.aabb = AABB.merge(pivot.left.aabb, pivot.right.aabb)
-    #             # update self
-    #             self.left  = pivot.left
-    #             self.right = pivot.right
-    #             self.aabb  = pivot.aabb
-    #             # new depth difference
-    #             diff = self.left.depth - self.right.depth
-
     def get_collisions(self, detect_collision):
-        """return collisions according to provided function"""
+        """Return collisions according to provided function"""
         collisions = []
         stack = [self]
         while stack:
@@ -648,19 +617,19 @@ class PdfAlign(Frame):
         self.ann_mode_list = ["eqn", "text", "desc", "unit"]
 
         toolbar = Frame(self)
-        Button(toolbar, text="Open", command=self.open).pack(side=LEFT)
-        Button(toolbar, text="Import", command=self.import_annotations).pack(
+        Button(toolbar, text="Open (o)", command=self.open).pack(side=LEFT)
+        Button(toolbar, text="Import (i)", command=self.import_annotations).pack(
             side=LEFT
         )
-        Button(toolbar, text="Previous page", command=self.prev).pack(
+        Button(toolbar, text="◀", command=self.prev).pack(
             side=LEFT
         )
-        Button(toolbar, text="Next page", command=self.next).pack(side=LEFT)
-        Button(toolbar, text="Zoom in", command=self.zoom_in).pack(side=LEFT)
-        Button(toolbar, text="Zoom out", command=self.zoom_out).pack(side=LEFT)
+        Button(toolbar, text="▶", command=self.next).pack(side=LEFT)
+        Button(toolbar, text="Zoom in (+)", command=self.zoom_in).pack(side=LEFT)
+        Button(toolbar, text="Zoom out (-)", command=self.zoom_out).pack(side=LEFT)
         ttk.Label(toolbar, textvariable=self.num_page_tv).pack(side=LEFT)
 
-        ttk.Label(toolbar, text="Token mode").pack(side=LEFT)
+        ttk.Label(toolbar, text="Token mode (k)").pack(side=LEFT)
         self.token_mode_on_rb = Radiobutton(
             toolbar,
             text="on",
@@ -679,14 +648,14 @@ class PdfAlign(Frame):
         self.token_mode_off_rb.pack(side=LEFT)
 
         Button(
-            toolbar, text="Annotate new variable", command=self.new_annotation
+            toolbar, text="Annotate new variable (n)", command=self.new_annotation
         ).pack(side=LEFT)
-        Button(toolbar, text="Add component", command=self.add_component).pack(
+        Button(toolbar, text="Add component (c)", command=self.add_component).pack(
             side=LEFT
         )
         self.in_equation_rb = Radiobutton(
             toolbar,
-            text="In equation",
+            text="In equation (e)",
             value="equation",
             variable=self.annotation_mode,
             command=self.select_equation,
@@ -695,7 +664,7 @@ class PdfAlign(Frame):
         self.in_equation_rb.pack(side=LEFT)
         self.in_text_rb = Radiobutton(
             toolbar,
-            text="In text",
+            text="In text (t)",
             value="text",
             variable=self.annotation_mode,
             command=self.select_text,
@@ -704,7 +673,7 @@ class PdfAlign(Frame):
         self.in_text_rb.pack(side=LEFT)
         self.description_rb = Radiobutton(
             toolbar,
-            text="Description",
+            text="Description (d)",
             value="description",
             variable=self.annotation_mode,
             command=self.select_description,
@@ -713,38 +682,43 @@ class PdfAlign(Frame):
         self.description_rb.pack(side=LEFT)
         self.unit_rb = Radiobutton(
             toolbar,
-            text="Unit",
+            text="Unit (u)",
             value="unit",
             variable=self.annotation_mode,
             command=self.select_unit,
             style="Unit.TRadiobutton",
         )
         self.unit_rb.pack(side=LEFT)
-        Button(toolbar, text="Save", command=self.save_annotation).pack(
+        Button(toolbar, text="Save (s)", command=self.save_annotation).pack(
             side=LEFT
         )
-        Button(toolbar, text="Export", command=self.export_annotations).pack(
+        Button(toolbar, text="Export (x)", command=self.export_annotations).pack(
             side=LEFT
         )
-        Button(toolbar, text="Quit", command=self.client_exit).pack(side=LEFT)
+        Button(toolbar, text="Quit (q)", command=self.client_exit).pack(side=LEFT)
         toolbar.pack(side=TOP, fill=BOTH)
 
         # Keyboard shortcuts
         self.bind_all("o", lambda e: self.open())
-        self.bind_all("a", lambda e: self.add_component())
-        self.bind_all("e", lambda e: self.in_equation_rb.invoke())
-        self.bind_all("t", lambda e: self.in_text_rb.invoke())
-        self.bind_all("d", lambda e: self.description_rb.invoke())
-        self.bind_all("u", lambda e: self.unit_rb.invoke())
-        self.bind_all("s", lambda e: self.save_annotation())
-        self.bind_all("k", lambda e: self.toggle_boxes())
-        self.bind_all("n", lambda e: self.new_annotation())
-        self.bind_all("x", lambda e: self.export_annotations())
-        self.bind_all("c", lambda e: self.add_component())
+        self.bind_all("i", lambda e: self.import_annotations())
         self.bind_all("+", lambda e: self.zoom_in())
         self.bind_all("-", lambda e: self.zoom_out())
         self.bind_all("<Left>", lambda e: self.prev())
         self.bind_all("<Right>", lambda e: self.next())
+
+        self.bind_all("n", lambda e: self.new_annotation())
+        self.bind_all("c", lambda e: self.add_component())
+
+        self.bind_all("k", lambda e: self.toggle_boxes())
+
+        self.bind_all("e", lambda e: self.in_equation_rb.invoke())
+        self.bind_all("t", lambda e: self.in_text_rb.invoke())
+        self.bind_all("d", lambda e: self.description_rb.invoke())
+        self.bind_all("u", lambda e: self.unit_rb.invoke())
+
+        self.bind_all("s", lambda e: self.save_annotation())
+        self.bind_all("x", lambda e: self.export_annotations())
+        self.bind_all("q", lambda e: self.client_exit())
         self.bind_all("<Tab>", lambda e: self.next_mode())
 
         viewer = Frame(self)

--- a/pdfalign/pdfalign.py
+++ b/pdfalign/pdfalign.py
@@ -713,7 +713,7 @@ class PdfAlign(Frame):
         self.bind_all("<Right>", lambda e: self.next())
 
         self.bind_all("n", lambda e: self.new_annotation())
-        self.bind_all("c", lambda e: self.add_component())
+        self.bind_all("a", lambda e: self.add_component())
 
         self.bind_all("k", lambda e: self.toggle_boxes())
 

--- a/pdfalign/setup.py
+++ b/pdfalign/setup.py
@@ -7,6 +7,7 @@ setup(
     author="ML4AI",
     version="0.0.1",
     install_requires=[
+        "tqdm",
         "lxml",
         "webcolors",
         "pdf2image",


### PR DESCRIPTION
This PR implements the following improvements:

- Adds tqdm progress bars to the terminal (for the impatient)
- Speeds up bounding box tree construction by pre-sorting by area (2x speedup for token boxes, 3.5x speedup for character boxes)
- pdfalign automatically jumps to the page containing the equation in the paper when it is opened.
- Buttons now have the associated keyboard shortcuts in their label.
- Previous page/next page button labels replaced with arrowheads.