### PR TITLE
making sections and year options when reading science parse produced …

### DIFF
--- a/text_reading/src/main/scala/org/clulab/aske/automates/data/DataLoader.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/data/DataLoader.scala
@@ -48,7 +48,9 @@ class ScienceParsedDataLoader extends DataLoader {
     // todo: this approach should like be revisited to handle sections more elegantly, or to omit some, etc.
     //the heading and the text of the section are currently combined; might need to be revisted
     val scienceParseDoc = ScienceParseClient.mkDocument(f)
-    scienceParseDoc.sections.map(_.headingAndText) ++ scienceParseDoc.abstractText
+    if (scienceParseDoc.sections.isDefined)  {
+      scienceParseDoc.sections.get.map(_.headingAndText) ++ scienceParseDoc.abstractText
+    } else scienceParseDoc.abstractText.toSeq
   }
   override val extension: String = "json"
 }
@@ -77,7 +79,9 @@ class PDFDataLoader extends DataLoader {
     val jsonString = client.parsePdfToJson(f)
     val uJson = ujson.read(jsonString) //make a ujson value out of the json string we get from scienceParse; mkDocument does not work on plain string.
     val scienceParseDoc = ScienceParseClient.mkDocument(uJson)
-    scienceParseDoc.sections.map(_.headingAndText) ++ scienceParseDoc.abstractText
+    if (scienceParseDoc.sections.isDefined)  {
+      scienceParseDoc.sections.get.map(_.headingAndText) ++ scienceParseDoc.abstractText
+    } else scienceParseDoc.abstractText.toSeq
   }
   override val extension: String = "pdf"
 }

--- a/text_reading/src/main/scala/org/clulab/aske/automates/scienceparse/ScienceParseClient.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/scienceparse/ScienceParseClient.scala
@@ -26,10 +26,13 @@ object ScienceParseClient {
   def mkDocument(json: ujson.Js): ScienceParseDocument = {
     val id = json("id").str
     val title = json.obj.get("title").map(_.str)
-    val year = json("year").num.toInt
+    val year = json.obj.get("year")
     val authors = json("authors").arr.map(mkAuthor).toVector
     val abstractText = json.obj.get("abstractText").map(_.str)
-    val sections = json("sections").arr.map(mkSection).toVector
+    val sections = {
+      if (json.obj.get("sections").nonEmpty) Some(json("sections").arr.map(mkSection).toVector)
+      else None
+    }
     val references = json("references").arr.map(mkReference).toVector
     ScienceParseDocument(id, title, year, authors, abstractText, sections, references)
   }

--- a/text_reading/src/main/scala/org/clulab/aske/automates/scienceparse/ScienceParseDocument.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/scienceparse/ScienceParseDocument.scala
@@ -1,12 +1,14 @@
 package org.clulab.aske.automates.scienceparse
 
+import ujson.Value
+
 case class ScienceParseDocument(
   id: String,
   title: Option[String],
-  year: Int,
+  year: Option[Value],
   authors: Vector[Author],
   abstractText: Option[String],
-  sections: Vector[Section],
+  sections: Option[Vector[Section]],
   references: Vector[Reference]
 )
 


### PR DESCRIPTION
Some of the PDFs are partially parsed by Science Parse, e.g., come with just the abstract text parsed, but no 'sections' key in the json. Sometimes, they are missing the 'year' key. In these cases, these documents, which still contain some useful information, result in 'missing key' errors while being loaded. These changes here make 'sections' and 'year' keys optional, so more documents can be processed.

The ones missing sections so far are the older ones*, where even the abstract text is not too great (e.g., the variable Et was read as E1), so I'd still stay clear of the older ones (@pauldhein, I am working on checking the pdfs you collected, and will get back to you soon). 

*The year missing was on one of the newer papers, though. 
 