### PR TITLE
Vertical text + fixing the bug from previous PR

### DIFF
--- a/text_reading/src/main/resources/org/clulab/aske_automates/grammars/entities/grammar/avoid.yml
+++ b/text_reading/src/main/resources/org/clulab/aske_automates/grammars/entities/grammar/avoid.yml
@@ -27,7 +27,7 @@ rules:
     type: token
     pattern: |
       # avoid xrefs
-      [tag=/NNP|FW/] (?="et" "al")
+      [tag=/NNP|FW/] (?="et" "al") | [tag=/NNP|FW/] (?="et" "al.")
 
   - name: "et-al"
     label: Avoid

--- a/text_reading/src/main/scala/org/clulab/aske/automates/data/Preprocessor.scala
+++ b/text_reading/src/main/scala/org/clulab/aske/automates/data/Preprocessor.scala
@@ -10,7 +10,8 @@ class EdgeCaseParagraphPreprocessor() extends Preprocessor {
     def cleanUp(text: String): String = {
     //follow up on combining the heading and the body of each section in the paper with "\n" in the DataLoader:
     //the heading and the body should be connected with a period if the body starts with a capital letter and space otherwise:
-    val cleanerText = text.replaceAll("\n(?=[A-Z])", ". ").replaceAll("\n", " ")
+    val loseVerticalText = text.split("\n").filter(t => t.length > 6).mkString("\n")
+    val cleanerText = loseVerticalText.replaceAll("\n(?=[A-Z])", ". ").replaceAll("\n", " ")
     val cleanerTextTokenized = cleanerText.split(" ")
     val numberOfNumbers = cleanerTextTokenized.filter(t => t.forall(_.isDigit)).length
     val numberProportion = numberOfNumbers.toFloat / cleanerTextTokenized.length
@@ -40,7 +41,8 @@ object EdgeCaseParagraphPreprocessor {
 
 class PassThroughPreprocessor() extends Preprocessor {
   def cleanUp(text: String): String = {
-    val cleanerText = text.replaceAll("\n", " ")
+    val loseVerticalText = text.split("\n").filter(t => t.length > 6).mkString("\n")
+    val cleanerText = loseVerticalText.replaceAll("\n", " ")
     cleanerText
   }
 }

--- a/text_reading/webapp/app/controllers/HomeController.scala
+++ b/text_reading/webapp/app/controllers/HomeController.scala
@@ -136,7 +136,9 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     val pdfFile = json("pdf").str
     logger.info(s"Extracting mentions from $pdfFile")
     val scienceParseDoc = scienceParse.parsePdf(pdfFile)
-    val texts = scienceParseDoc.sections.map(_.headingAndText) ++ scienceParseDoc.abstractText
+    val texts = if (scienceParseDoc.sections.isDefined)  {
+      scienceParseDoc.sections.get.map(_.headingAndText) ++ scienceParseDoc.abstractText
+    } else scienceParseDoc.abstractText.toSeq
     logger.info("Finished converting to text")
     val mentions = texts.flatMap(t => ieSystem.extractFromText(t, keepText = true, filename = Some(pdfFile)))
     val mentionsJson = serializer.jsonAST(mentions)


### PR DESCRIPTION
1. Filter out ugly strings that result from pdfs having vertical text, e.g., 
![Screenshot from 2020-03-23 16-18-34](https://user-images.githubusercontent.com/31713912/77372057-08ab9680-6d22-11ea-964e-d0b996ca3642.png)
2. Fix bug from previous PR---one of the methods in HomeController included reading sections from the pdf, and the sections key is now optional. 