### PR TITLE
svo query terms added to text_var link element

### DIFF
--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
@@ -7,7 +7,7 @@ import ai.lum.common.FileUtils._
 import com.typesafe.config.{Config, ConfigFactory}
 import org.clulab.aske.automates.data.{DataLoader, TextRouter, TokenizedLatexDataLoader}
 import org.clulab.aske.automates.alignment.{Aligner, Alignment, AlignmentHandler, VariableEditDistanceAligner}
-import org.clulab.aske.automates.grfn.GrFNParser.{mkHypothesis, mkLinkElement}
+import org.clulab.aske.automates.grfn.GrFNParser.{mkHypothesis, mkLinkElement, mkTextLinkElement}
 import org.clulab.aske.automates.OdinEngine
 import org.clulab.aske.automates.entities.GrFNEntityFinder
 import org.clulab.aske.automates.grfn.GrFNParser
@@ -225,11 +225,12 @@ object ExtractAndAlign {
       val docId = mention.document.id.getOrElse("unk_text_file")
       val sent = mention.sentence
       val offsets = mention.tokenInterval.toString()
-      mkLinkElement(
+      mkTextLinkElement(
         elemType = "text_var",
         source = s"${docId}_sent${sent}_$offsets",
         content = mention.arguments(VARIABLE).head.text,
-        contentType = "null"
+        contentType = "null",
+        svoQueryTerms = SVOGrounder.getTerms(mention).getOrElse(Seq.empty)
       )
     }
 

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/grfn/GrFNParser.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/grfn/GrFNParser.scala
@@ -110,6 +110,16 @@ object GrFNParser {
     linkElement
   }
 
+  def mkTextLinkElement(elemType: String, source: String, content: String, contentType: String, svoQueryTerms: Seq[String]): ujson.Obj = {
+    val linkElement = ujson.Obj(
+      "type" -> elemType,
+      "source" -> source,
+      "content" -> content,
+      "content_type" -> contentType,
+      "svo_query_terms" -> svoQueryTerms
+    )
+    linkElement
+  }
 
   def mkCommentTextElement(text: String, source: String, container: String, location: String): ujson.Obj = {
     val commentTextElement = ujson.Obj(

--- a/src/text_reading/src/main/scala/org/clulab/grounding/Grounder.scala
+++ b/src/text_reading/src/main/scala/org/clulab/grounding/Grounder.scala
@@ -173,7 +173,7 @@ object SVOGrounder {
   * only look at the terms in the definition mentions for now*/
   def getTerms(mention: Mention): Option[Seq[String]] = {
     //todo: will depend on type of mention, e.g., for definitions, only look at the words in the definition arg, not var itself
-    println("Getting search terms for the mention")
+//    println("Getting search terms for the mention")
     if (mention matches "Definition") {
       val terms = new ArrayBuffer[String]()
 
@@ -231,11 +231,11 @@ object SVOGrounder {
       //get indices of compounds or modifiers to the head word of the mention
       val outgoingNodes = outgoing.map(o => o._1)
 
-        //check if two previous words are parts of a compound
+        //check if two previous words are parts of a compound---two words window was chosen based on seen examples
         for (i <- 1 to 2) {
           val idxToCheck = mention.synHead.get - i
           if (outgoingNodes.contains(idxToCheck)) {
-            //ideally need to add an nmod_of here; would require checking cur word + 2; todo: check if SVO has 'of' terms
+            //ideally need to add an nmod_of here; would require checking cur word + 2-3;
             if (outgoing.exists(item => item._1 == idxToCheck && (item._2 == "compound" || item._2 == "amod"))) {
 
               val newComp = mention.sentenceObj.words.slice(idxToCheck,mention.synHead.get + 1).mkString("_")


### PR DESCRIPTION
@BeckySharp, is this roughly what you had in mind? This adds a section to the link element that contains potential terms to query svo for for this text variable, e.g.:

```
"element_1": {
	"source": "/Users/phein/Google Drive/ASKE-AutoMATES/Data/Mini-SPAM/docs/SPAM/PET/petpt_2012.pdf_sent72_Interval(0, 6)",
	"content_type": "null",
	"svo_query_terms": ["index", "area_index", "Leaf_area_index"],
	"content": "LAI",
	"type": "text_var"
}

```
@pauldhein, would you be able to query svo with those terms there? 