### PR TITLE
Svo terms in text link el

### DIFF
--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
@@ -7,7 +7,7 @@ import ai.lum.common.FileUtils._
 import com.typesafe.config.{Config, ConfigFactory}
 import org.clulab.aske.automates.data.{DataLoader, TextRouter, TokenizedLatexDataLoader}
 import org.clulab.aske.automates.alignment.{Aligner, Alignment, AlignmentHandler, VariableEditDistanceAligner}
-import org.clulab.aske.automates.grfn.GrFNParser.{mkHypothesis, mkLinkElement}
+import org.clulab.aske.automates.grfn.GrFNParser.{mkHypothesis, mkLinkElement, mkTextLinkElement}
 import org.clulab.aske.automates.OdinEngine
 import org.clulab.aske.automates.entities.GrFNEntityFinder
 import org.clulab.aske.automates.grfn.GrFNParser
@@ -225,11 +225,12 @@ object ExtractAndAlign {
       val docId = mention.document.id.getOrElse("unk_text_file")
       val sent = mention.sentence
       val offsets = mention.tokenInterval.toString()
-      mkLinkElement(
+      mkTextLinkElement(
         elemType = "text_var",
         source = s"${docId}_sent${sent}_$offsets",
         content = mention.arguments(VARIABLE).head.text,
-        contentType = "null"
+        contentType = "null",
+        svoQueryTerms = SVOGrounder.getTerms(mention).getOrElse(Seq.empty)
       )
     }
 

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/grfn/GrFNParser.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/grfn/GrFNParser.scala
@@ -110,6 +110,16 @@ object GrFNParser {
     linkElement
   }
 
+  def mkTextLinkElement(elemType: String, source: String, content: String, contentType: String, svoQueryTerms: Seq[String]): ujson.Obj = {
+    val linkElement = ujson.Obj(
+      "type" -> elemType,
+      "source" -> source,
+      "content" -> content,
+      "content_type" -> contentType,
+      "svo_query_terms" -> svoQueryTerms
+    )
+    linkElement
+  }
 
   def mkCommentTextElement(text: String, source: String, container: String, location: String): ujson.Obj = {
     val commentTextElement = ujson.Obj(

--- a/src/text_reading/src/main/scala/org/clulab/grounding/Grounder.scala
+++ b/src/text_reading/src/main/scala/org/clulab/grounding/Grounder.scala
@@ -201,8 +201,8 @@ object SVOGrounder {
           }
         }
       }
-
-      Some(terms.sortBy(_.length))
+      val finalTerms = terms.map(t => t.filter(ch => ch.isLetter || ch.toString == "-" || ch.toString == "_"))
+      Some(finalTerms.sortBy(_.length))
     } else None
 
   }
@@ -238,7 +238,7 @@ object SVOGrounder {
             //ideally need to add an nmod_of here; would require checking cur word + 2-3;
             if (outgoing.exists(item => item._1 == idxToCheck && (item._2 == "compound" || item._2 == "amod"))) {
 
-              val newComp = mention.sentenceObj.words.slice(idxToCheck,mention.synHead.get + 1).mkString("_")
+              val newComp = mention.sentenceObj.words.slice(idxToCheck,mention.synHead.get + 1).filter(w => w.count(_.isLetter) == w.length).mkString("_")
               //fixme: if grounder not too slow, also get compounds separated by "-" bc those also occur in SVO
               compoundWords.append(newComp)
             }

--- a/src/text_reading/src/main/scala/org/clulab/grounding/Grounder.scala
+++ b/src/text_reading/src/main/scala/org/clulab/grounding/Grounder.scala
@@ -173,7 +173,7 @@ object SVOGrounder {
   * only look at the terms in the definition mentions for now*/
   def getTerms(mention: Mention): Option[Seq[String]] = {
     //todo: will depend on type of mention, e.g., for definitions, only look at the words in the definition arg, not var itself
-    println("Getting search terms for the mention")
+//    println("Getting search terms for the mention")
     if (mention matches "Definition") {
       val terms = new ArrayBuffer[String]()
 
@@ -231,11 +231,11 @@ object SVOGrounder {
       //get indices of compounds or modifiers to the head word of the mention
       val outgoingNodes = outgoing.map(o => o._1)
 
-        //check if two previous words are parts of a compound
+        //check if two previous words are parts of a compound---two words window was chosen based on seen examples
         for (i <- 1 to 2) {
           val idxToCheck = mention.synHead.get - i
           if (outgoingNodes.contains(idxToCheck)) {
-            //ideally need to add an nmod_of here; would require checking cur word + 2; todo: check if SVO has 'of' terms
+            //ideally need to add an nmod_of here; would require checking cur word + 2-3;
             if (outgoing.exists(item => item._1 == idxToCheck && (item._2 == "compound" || item._2 == "amod"))) {
 
               val newComp = mention.sentenceObj.words.slice(idxToCheck,mention.synHead.get + 1).mkString("_")


### PR DESCRIPTION
Hi @pauldhein,

The changes in this commit https://github.com/ml4ai/automates/commit/d0c68b39a49e8deac5887bd01369f0f6383ed392 should fix your svo error from yesterday (the error was because there was a regex special character in the query term---the closing paren). 

For this commit, I was working on the same local branch that I used for my previous PR---big mistake. For some reason, the commit that should have already been merged (and I'm pretty sure the changes are already in endpoint) shows up here as well. Do you know what that's about? Hope that does not break anything. 

@BeckySharp, just fyi---that commit is what I ended up doing at least as a temp solution for the special character in queries issue we discussed. 
 