### PR TITLE
Separating align

### DIFF
--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/grfn/GrFNParser.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/grfn/GrFNParser.scala
@@ -14,7 +14,8 @@ import scala.collection.mutable.ArrayBuffer
 object GrFNParser {
 
   def addHypotheses(grfn: Value, hypotheses: Seq[Obj]): Value = {
-    grfn("grounding") = hypotheses.toList
+    //adding to exisitng grounding; intended to help with running complementary endpoints (instead of the full pipeline)
+    grfn("grounding") = (grfn("grounding").arr ++ hypotheses.toList).distinct
     grfn
   }
 

--- a/src/text_reading/webapp/app/controllers/HomeController.scala
+++ b/src/text_reading/webapp/app/controllers/HomeController.scala
@@ -215,6 +215,8 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     Ok(PlayUtils.toPlayJson(groundedGrfnJson4s))
   }
 
+
+  /**Align everything except for equations**/
   def alignDocstringsAndText: Action[AnyContent] = Action { request =>
     val toAlign = Seq("Comment", "Text")
     val data = request.body.asJson.get.toString()
@@ -243,6 +245,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   }
 
 
+  /**get arguments for the aligner depending on what's needed for each endpoint**/
   def getArgsForAlignment(json: Value, toAlign: Seq[String]): alignmentArguments = {
 
     // load text mentions

--- a/src/text_reading/webapp/conf/routes
+++ b/src/text_reading/webapp/conf/routes
@@ -12,6 +12,7 @@ POST     /groundMentionsToSVO       controllers.HomeController.groundMentionsToS
 POST    /process_text               controllers.HomeController.process_text
 POST    /pdf_to_mentions            controllers.HomeController.pdf_to_mentions
 POST    /align                      controllers.HomeController.align
+POST    /alignDocstringsAndText     controllers.HomeController.alignDocstringsAndText
 POST    /jsonDoc_to_mentions        controllers.HomeController.jsonDoc_to_mentions
 
 


### PR DESCRIPTION
@BeckySharp, this is a proposal on how to separate align into different endpoints. This is the gist:

1. Using options in various align methods (e.g., in getLinkElements and mkLinkHypothesis) to avoid breaking up linkElement and linkHypothesis-related methods---there is finally a full pipeline, and I hate to break it up. 

2. For every align-related endpoint (see _Note_),  there is a method that gets all the necessary arguments depending on what we want to link:
https://github.com/ml4ai/automates/blob/1367c4a0fd65b34c0ce5688235eb5f8c3303acf9/src/text_reading/webapp/app/controllers/HomeController.scala#L249
There's a _toAlign_ list in each endpoint, telling it what needs aligned, e.g., https://github.com/ml4ai/automates/blob/1367c4a0fd65b34c0ce5688235eb5f8c3303acf9/src/text_reading/webapp/app/controllers/HomeController.scala#L192

_Note:_ now, as a prototype, there are two endpoints: 
- align---to align everything
- alignDocstringsAndText---that does not include equation linking, with equation production was a bottleneck that stopped us from running the pipeline 

3. Fwiw, it's usable for Paul to run the pipeline for cases when some of the input, e.g., equations, is missing, but we can definitely discuss a better way to do this in our Monday meeting.  

Also, `main` method in `ExtractAndAlign` is temporarily commented out---I will adjust it after the other changes are finalized. 