### PR TITLE
Debug eqs

### DIFF
--- a/src/text_reading/src/main/resources/application.conf
+++ b/src/text_reading/src/main/resources/application.conf
@@ -79,7 +79,7 @@ apps {
   //=====AlignmentBaselineData=====
   baselineDir = "./input/LREC/dev"
   baselineOutputDirectory = "./output/LRECBaseline"
-  pdfalignDir = "/home/alexeeva/Repos/automates/pdfalign" //todo: relative path
+  pdfalignDir = "/home/alexeeva/Repos/automates/src/apps/pdfalign" //todo: relative path
 
   baselineTextInputDirectory = ${apps.baselineDir}/ParsedJsons
   baselineEquationDir = ${apps.baselineDir}/equations

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/alignment/Aligner.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/alignment/Aligner.scala
@@ -40,9 +40,9 @@ class VariableEditDistanceAligner(relevantArgs: Set[String] = Set("variable")) {
   def alignEqAndTexts(srcTexts: Seq[String], dstTexts: Seq[String]): Seq[Alignment] = {
     val exhaustiveScores = for {
       (src, i) <- srcTexts.zipWithIndex
-      rendered = AlignmentBaseline.customRender(src)
+      rendered = AlignmentBaseline.renderForAlign(src)
       (dst, j) <- dstTexts.zipWithIndex
-      score = 1.0 / (editDistance(rendered, dst) + 1.0) // todo: is this good for long-term?
+      score = 1.0 / (editDistance(rendered, dst) + 1.0) // todo: is this good for long-term? next thing to try: only align if rendered starts with the same letter as actual---might need to make this output an option in case if there are no alignments
     } yield Alignment(i, j, score)
     // redundant but good for debugging
     exhaustiveScores

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/alignment/Aligner.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/alignment/Aligner.scala
@@ -6,6 +6,7 @@ import ai.lum.common.ConfigUtils._
 import org.clulab.embeddings.word2vec.Word2Vec
 import org.clulab.odin.{EventMention, Mention, RelationMention, TextBoundMention}
 import org.apache.commons.text.similarity.LevenshteinDistance
+import org.clulab.aske.automates.apps.AlignmentBaseline
 
 case class AlignmentHandler(editDistance: VariableEditDistanceAligner, w2v: PairwiseW2VAligner) {
   def this(w2vPath: String, relevantArgs: Set[String]) =
@@ -31,6 +32,17 @@ class VariableEditDistanceAligner(relevantArgs: Set[String] = Set("variable")) {
       (src, i) <- srcTexts.zipWithIndex
       (dst, j) <- dstTexts.zipWithIndex
       score = 1.0 / (editDistance(src, dst) + 1.0) // todo: is this good for long-term?
+    } yield Alignment(i, j, score)
+    // redundant but good for debugging
+    exhaustiveScores
+  }
+
+  def alignEqAndTexts(srcTexts: Seq[String], dstTexts: Seq[String]): Seq[Alignment] = {
+    val exhaustiveScores = for {
+      (src, i) <- srcTexts.zipWithIndex
+      rendered = AlignmentBaseline.customRender(src)
+      (dst, j) <- dstTexts.zipWithIndex
+      score = 1.0 / (editDistance(rendered, dst) + 1.0) // todo: is this good for long-term?
     } yield Alignment(i, j, score)
     // redundant but good for debugging
     exhaustiveScores

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/AlignmentBaseline.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/AlignmentBaseline.scala
@@ -526,10 +526,12 @@ object AlignmentBaseline {
   val greekLetterLines = loadStringsFromResource("/AlignmentBaseline/greek2words.tsv")
   //these will be used to map greek letters to words and back
   val word2greekDict = mutable.Map[String, String]()
+  val greek2wordDict = mutable.Map[String, String]()
   for (line <- greekLetterLines) {
     val splitLine = line.split("\t")
     //      greek2wordDict += (splitLine.head -> splitLine.last)
     word2greekDict += (splitLine.last -> splitLine.head)
+    greek2wordDict += (splitLine.head -> splitLine.last)
   }
 
   def main(args:Array[String]) {
@@ -562,9 +564,26 @@ object AlignmentBaseline {
     toReturn
   }
 
+  def replaceGreekWithWord(varName: String, greek2wordDict: Map[String, String]): String = {
+    var toReturn = varName
+    for (k <- greek2wordDict.keys) {
+      if (varName.contains(k)) {
+        toReturn = toReturn.replace(k, s"""\\\\${greek2wordDict(k)}""")
+      }
+    }
+    toReturn
+  }
+
   def customRender(cand: String): String = {
     println("Start rend one cand")
     val rendered = render(replaceWordWithGreek(cand, word2greekDict.toMap), pdfalignDir).replaceAll("\\s", "")
+    println("rendered: " + rendered + " original: " + cand)
+    rendered
+  }
+
+  def renderForAlign(cand: String): String = {
+    println("Start rend one cand")
+    val rendered = render(cand, pdfalignDir).replaceAll("\\s", "")
     println("rendered: " + rendered + " original: " + cand)
     rendered
   }

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
@@ -320,7 +320,6 @@ object ExtractAndAlign {
     if (linkElKeys.toSeq.contains(EQUATION) && linkElKeys.toSeq.contains(TEXT)) {
       hypotheses.appendAll(mkLinkHypothesis(linkElements(EQUATION), linkElements(TEXT), alignments(EQN_TO_TEXT)))
     }
-    val eqHyp = mkLinkHypothesis(linkElements(EQUATION), linkElements(TEXT), alignments(EQN_TO_TEXT))
 
     // TextVar -> TextDef (text_span)
     if (linkElKeys.toSeq.contains(TEXT_VAR) && linkElKeys.toSeq.contains(TEXT)) {

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/apps/ExtractAndAlign.scala
@@ -102,7 +102,13 @@ object ExtractAndAlign {
     // tuple pairing each chunk with the original latex equation it came from
     for {
       sourceEq <- equations
-      eqChunk <- equationDataLoader.chunkLatex(sourceEq).filter(cand => cand.count(char => !char.isSpaceChar) <= 15 && cand.count(char => char.isDigit) < 2).map(c => AlignmentBaseline.replaceWordWithGreek(c, word2greekDict.toMap))//.replace("\\\\\\w+\\s", "\\s"))// keep the ones that have less than 15 non-space chars and don't allow digits
+      eqChunk <- equationDataLoader.chunkLatex(sourceEq)
+        .filter(cand => cand.count(char => !char.isSpaceChar) <= 15 && cand.count(char => char.isDigit) < 2)
+        .filter(cand => is_balanced(cand))
+        .filter(chunk => !chunk.matches("\\\\\\w+"))
+          .map(c => AlignmentBaseline.replaceWordWithGreek(c, word2greekDict.toMap))
+
+        //.replace("\\\\\\w+\\s", "\\s"))// keep the ones that have less than 15 non-space chars and don't allow digits
     } yield (eqChunk, sourceEq)
   }
 
@@ -330,6 +336,21 @@ object ExtractAndAlign {
 
 
     hypotheses
+  }
+
+
+  def is_balanced(string: String): Boolean = {
+    is_balanced_delim(string, "(", ")") && is_balanced_delim(string, "{", "}") && is_balanced_delim(string, "[", "]")
+  }
+
+  def is_balanced_delim(string: String, open_delim: String, close_delim: String): Boolean = {
+    var n_open = 0
+    for (char <- string) {
+      if (char.toString == open_delim) n_open += 1 else if (char.toString == close_delim) n_open -= 1
+      if (n_open < 0) return false
+
+    }
+    n_open == 0
   }
 
   def main(args: Array[String]): Unit = {

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/data/DataLoader.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/data/DataLoader.scala
@@ -148,21 +148,6 @@ class TokenizedLatexDataLoader extends DataLoader {
     tokens.filter(_.exists(char => char.isLetter))
   }
 
-//  def chunkLatexWithRendering(equation: String): Map[String, String] = {
-//    val pdfAlignDir = "/home/alexeeva/Repos/automates/pdfalign"
-//    val allEqVarCandidates = AlignmentBaseline.getFrags(equation, pdfAlignDir)
-//      .split("\n")
-//      // keep the ones that have less than 50 non-space chars
-//      .filter(cand => cand.count(char => !char.isSpaceChar) <= 50)
-//
-//
-//    val renderedAll = mutable.HashMap[String, String]()
-//    for (variableCand <- allEqVarCandidates) {
-//      renderedAll.put(variableCand, AlignmentBaseline.customRender(variableCand))
-//    }
-//
-//    renderedAll.toMap
-//  }
 }
 
 

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/data/DataLoader.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/data/DataLoader.scala
@@ -3,9 +3,11 @@ package org.clulab.aske.automates.data
 import java.io.File
 
 import ai.lum.common.StringUtils._
+import org.clulab.aske.automates.apps.AlignmentBaseline
 import org.clulab.aske.automates.scienceparse.ScienceParseClient
 import org.clulab.utils.FileUtils.getTextFromFile
 
+import scala.collection.mutable
 import scala.util.matching.Regex
 
 
@@ -145,6 +147,22 @@ class TokenizedLatexDataLoader extends DataLoader {
     // keep the ones with alpha chars
     tokens.filter(_.exists(char => char.isLetter))
   }
+
+//  def chunkLatexWithRendering(equation: String): Map[String, String] = {
+//    val pdfAlignDir = "/home/alexeeva/Repos/automates/pdfalign"
+//    val allEqVarCandidates = AlignmentBaseline.getFrags(equation, pdfAlignDir)
+//      .split("\n")
+//      // keep the ones that have less than 50 non-space chars
+//      .filter(cand => cand.count(char => !char.isSpaceChar) <= 50)
+//
+//
+//    val renderedAll = mutable.HashMap[String, String]()
+//    for (variableCand <- allEqVarCandidates) {
+//      renderedAll.put(variableCand, AlignmentBaseline.customRender(variableCand))
+//    }
+//
+//    renderedAll.toMap
+//  }
 }
 
 

--- a/src/text_reading/src/main/scala/org/clulab/utils/AlignmentUtils.scala
+++ b/src/text_reading/src/main/scala/org/clulab/utils/AlignmentUtils.scala
@@ -41,7 +41,7 @@ object AlignmentJsonUtils {
       Some(ExtractAndAlign.processEquations(equations)) //provides ALL var candidates
     } else None
 
-    for (item <- equationChunksAndSource.get) println(item._1 + " | " + item._2)
+//    for (item <- equationChunksAndSource.get) println(item._1 + " | " + item._2)
 
     val variableNames = if (jsonKeys.contains("source_code")) {
       Some(json("source_code").obj("variables").arr.map(_.obj("name").str))

--- a/src/text_reading/src/main/scala/org/clulab/utils/AlignmentUtils.scala
+++ b/src/text_reading/src/main/scala/org/clulab/utils/AlignmentUtils.scala
@@ -38,8 +38,10 @@ object AlignmentJsonUtils {
     // get the equations
     val equationChunksAndSource = if (jsonKeys.contains("equations")) {
       val equations = json("equations").arr
-      Some(ExtractAndAlign.processEquations(equations))
+      Some(ExtractAndAlign.processEquations(equations)) //provides ALL var candidates
     } else None
+
+    for (item <- equationChunksAndSource.get) println(item._1 + " | " + item._2)
 
     val variableNames = if (jsonKeys.contains("source_code")) {
       Some(json("source_code").obj("variables").arr.map(_.obj("name").str))

--- a/src/text_reading/src/main/scala/org/clulab/utils/AlignmentUtils.scala
+++ b/src/text_reading/src/main/scala/org/clulab/utils/AlignmentUtils.scala
@@ -38,7 +38,7 @@ object AlignmentJsonUtils {
     // get the equations
     val equationChunksAndSource = if (jsonKeys.contains("equations")) {
       val equations = json("equations").arr
-      Some(ExtractAndAlign.processEquations(equations)) //provides ALL var candidates
+      Some(ExtractAndAlign.processEquations(equations))
     } else None
 
 //    for (item <- equationChunksAndSource.get) println(item._1 + " | " + item._2)


### PR DESCRIPTION
This should solve the issue with the equation alignment:

- filtering out equations chunks that have unbalanced parens, sq. brackets, and curly braces;

- using rendering from AlignmentBaseline;

- filtering out chunks that consist of only one latex control sequence.