### PR TITLE
Fixing paths in equation documentation

### DIFF
--- a/docs/software.md
+++ b/docs/software.md
@@ -5,6 +5,6 @@ title: Software
 The machine reading of the scientific papers is done using a tool built upon
 [processors](https://github.com/clulab/processors), the parsing of equations in
 PDFs of scientific papers is done using the
-[equation parser module]({{ site.baseurl }}/equation_extraction/README/), and the program
+[equation parser module]({{ site.baseurl }}/src/equation_reading/equation_extraction/README/), and the program
 analysis and model assembly is performed by
 [Delphi](https://github.com/ml4ai/delphi).

--- a/src/equation_reading/equation_extraction/README.md
+++ b/src/equation_reading/equation_extraction/README.md
@@ -15,4 +15,4 @@ This module is being developed as part of the
 [AutoMATES](https://ml4ai.github.io/automates/) project at the University of
 Arizona.
 
-- [Github code repository](https://github.com/ml4ai/automates/tree/master/equation_extraction)
+- [Github code repository](https://github.com/ml4ai/automates/tree/master/src/equation_reading/equation_extraction)


### PR DESCRIPTION
This PR includes some simple path changes to fix the equation extraction documentation links on [the AutoMATES webpage](https://ml4ai.github.io/automates/software/). Closes #143 .