### PR TITLE
Tr debug

### DIFF
--- a/src/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
+++ b/src/text_reading/src/main/resources/org/clulab/aske_automates/grammars/comments/definitions.yml
@@ -12,5 +12,5 @@ rules:
 #    action: looksLikeAVariable #don't use this action here---the illegal "vars" should have been
     #filtered out in the entity rule
     pattern: |
-       @variable:Variable (?<definition> [word = /.*/ & !tag="-LRB-"]+)
+      @variable:Variable (?<definition> [word = /.*\w+.*/ & !tag="-LRB-"]+)
 

--- a/src/text_reading/src/main/resources/org/clulab/aske_automates/grammars/entities/grammar/avoid.yml
+++ b/src/text_reading/src/main/resources/org/clulab/aske_automates/grammars/entities/grammar/avoid.yml
@@ -116,5 +116,20 @@ rules:
     pattern: |
       [lemma = /this|the/]
 
+  - name: "eg"
+    label: Avoid
+    priority: 2
+    type: token
+    pattern: |
+      [lemma = "e.g"]
+
+  - name: "email"
+    label: Avoid
+    priority: 2
+    type: token
+    pattern: |
+      [lemma = /.*@.*\..*/]
+
+
 
 

--- a/src/text_reading/src/main/resources/org/clulab/aske_automates/grammars/entities/grammar/avoid.yml
+++ b/src/text_reading/src/main/resources/org/clulab/aske_automates/grammars/entities/grammar/avoid.yml
@@ -61,7 +61,7 @@ rules:
     pattern: |
       #avoids pointers to equations/figures as those are frequently found as variables
       #might need to be revisited
-      [word=/(?i)figs?|eqs?/] [word="."]?
+      [word=/(?i)figs?|eqs?|tables?/] [word="."]?
 
   # todo: verify that this prevents double finding when the StringMatchEF is used
   # todo: verify there are no expansion ramifications due to Avoid label

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/OdinActions.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/OdinActions.scala
@@ -28,7 +28,7 @@ class OdinActions(val taxonomy: Taxonomy, expansionHandler: Option[ExpansionHand
       val (expandable, other) = mentions.partition(m => m matches "Definition")
       val expanded = expansionHandler.get.expandArguments(expandable, state, validArgs) //todo: check if this is the best place for validArgs argument
       keepLongest(expanded) ++ other
-
+//        expanded ++ other
 
       //val mostComplete = keepMostCompleteEvents(expanded, state.updated(expanded))
       //val result = mostComplete ++ textBounds
@@ -45,6 +45,8 @@ class OdinActions(val taxonomy: Taxonomy, expansionHandler: Option[ExpansionHand
       m <- v
       // for overlapping mentions starting at the same token, keep only the longest
       longest = v.filter(_.tokenInterval.overlaps(m.tokenInterval)).maxBy(m => ((m.end - m.start) + 0.1 * m.arguments.size))
+      //      longest = v.filter(_.tokenInterval.start == m.tokenInterval.start).maxBy(m => ((m.end - m.start) + 0.1 * m.arguments.size))
+
     } yield longest
     mns.toVector.distinct
   }
@@ -193,7 +195,7 @@ class OdinActions(val taxonomy: Taxonomy, expansionHandler: Option[ExpansionHand
         looksLikeAVariable(defMention, state).isEmpty //makes sure the definition is not another variable (or does not look like what could be a variable)
         &&
         defMention.head.tokenInterval.intersect(variableMention.head.tokenInterval).isEmpty //makes sure the variable and the definition don't overlap
-        )
+        ) || (defMention.nonEmpty && freqWords.contains(defMention.head.text)) //the definition can be one short, frequent word
     } yield m
   }
 
@@ -250,7 +252,7 @@ class OdinActions(val taxonomy: Taxonomy, expansionHandler: Option[ExpansionHand
         case em: EventMention => m.arguments.getOrElse("definition", Seq()).head
         case _ => ???
       }
-      if (definText.text.filter(c => valid contains c).length.toFloat / definText.text.length > 0.60)
+      if definText.text.filter(c => valid contains c).length.toFloat / definText.text.length > 0.60
     } yield m
   }
 

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/OdinActions.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/OdinActions.scala
@@ -189,6 +189,7 @@ class OdinActions(val taxonomy: Taxonomy, expansionHandler: Option[ExpansionHand
       variableMention = m.arguments.getOrElse("variable", Seq())
       defMention = m.arguments.getOrElse("definition", Seq())
       if (
+        defMention.nonEmpty && //there has to be a definition
         looksLikeADef(defMention, state).nonEmpty && //make sure the def looks like a def
         defMention.head.text.length > 4 && //the def can't be the length of a var
         !defMention.head.text.contains("=") &&

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/actions/ExpansionHandler.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/actions/ExpansionHandler.scala
@@ -411,7 +411,7 @@ object ExpansionHandler {
     "^nmod_since".r,
     "^nmod_without$".r,
     "nummod".r,
-//    "^nsubj".r,
+    "^nsubj".r,
     "^punct".r,
     "^ref$".r,
     "appos".r

--- a/src/text_reading/src/main/scala/org/clulab/aske/automates/data/Preprocessor.scala
+++ b/src/text_reading/src/main/scala/org/clulab/aske/automates/data/Preprocessor.scala
@@ -42,7 +42,8 @@ object EdgeCaseParagraphPreprocessor {
 class PassThroughPreprocessor() extends Preprocessor {
   def cleanUp(text: String): String = {
     val loseVerticalText = text.split("\n").filter(t => t.length > 6).mkString("\n")
-    val cleanerText = loseVerticalText.replaceAll("\n", " ")
+    val loseExtraLongFalseWords = loseVerticalText.split(" ").filter(w => w.length < 25).mkString(" ")
+    val cleanerText = loseExtraLongFalseWords.replaceAll("\n", " ")
     cleanerText
   }
 }


### PR DESCRIPTION
Some debugging of text reading:

- comment defs have to have at least some letters in them (can't just be ")")
- a few avoids 
- filter out extra long "words" (results of science parse misprocessing)
- disallow expansion on nsubj
- allow short, freq word definitions