### PR TITLE
README Shields Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 <h1 align="center">Automated Model Assembly<br>from Text, Equations, and Software</h1>
 
 <p align="center">
-  <a href="https://github.com/ml4ai/automates">
+  <!-- <a href="https://github.com/ml4ai/automates">
    <img src="https://img.shields.io/github/license/ml4ai/automates" />
-  </a>
+  </a> -->
   <a href="https://hub.docker.com/r/ml4ailab/automates">
      <img src="https://img.shields.io/docker/cloud/build/ml4ailab/automates" alt="Docker cloud build status">
+  </a>
+  <a href="https://github.com/ml4ai/automates/actions">
+    <img src="https://img.shields.io/github/workflow/status/ml4ai/automates/Continuous%20Integration?label=tests" alt="GH Actions build status">
   </a>
   <a href="https://codecov.io/gh/ml4ai/automates">
    <img src="https://codecov.io/gh/ml4ai/automates/branch/master/graph/badge.svg" />
   </a>
-  <a href="https://travis-ci.org/ml4ai/automates">
-    <img src="https://img.shields.io/travis/com/ml4ai/automates/master.svg?label=Travis%20CI" alt="Travis build status">
-  </a>
+  <a href="https://www.codefactor.io/repository/github/ml4ai/automates"><img src="https://www.codefactor.io/repository/github/ml4ai/automates/badge" alt="CodeFactor" /></a>
 </p>
 
 This repository holds the source code for the AutoMATES documentation


### PR DESCRIPTION
## Updates
- Our UA addendum to the Apache 2.0 License is not recognizable by GitHub so I am removing the shield icon
- Our repository CodeFactor score is now displayed on the README. It's time to improve our score!