### PR TITLE
Text Reading web app configuration fix

### DIFF
--- a/automates/text_reading/src/main/resources/application.conf
+++ b/automates/text_reading/src/main/resources/application.conf
@@ -93,7 +93,7 @@ apps {
 
 alignment {
   alignerType = "pairwisew2v"
-  w2vPath = "/local/path/to/vectors.txt" // a word embeddings file (e.g., GloVe) with this header: <len_of_vocab><space><embedding_size>, e.g., "6B 50" (no quotes); use of different sets of embeddings will require adjusting alignment similarity thresholds, e.g., commentTextAlignmentScoreThreshold
+  w2vPath = "vectors.txt" // a word embeddings file (e.g., GloVe) with this header: <len_of_vocab><space><embedding_size>, e.g., "6B 50" (no quotes); use of different sets of embeddings will require adjusting alignment similarity thresholds, e.g., commentTextAlignmentScoreThreshold
   relevantArgs = ["variable", "description"]
 }
 


### PR DESCRIPTION
(Re-opening with fix commit history)

Hello @maxaalexeeva , @pauldhein was helping me set up the TR web app on machine so I can do some work on model assembly. We were encountering an issue where the TR app could not locate the vectors.txt file on certain API calls. The change in the apps configuration show in this pull request resolved the issue. Please review and let me know if the change works!