### PR TITLE
adjusting extract and export to use cosmos loader and updating what prints to tsv

### DIFF
--- a/automates/text_reading/src/main/resources/application.conf
+++ b/automates/text_reading/src/main/resources/application.conf
@@ -74,7 +74,7 @@ apps {
 
   outputDirectory = "./"
 
-  exportAs = ["serialized", "json"] // no other formats yet specified, but can be added!
+  exportAs =  ["tsv"]//,"serialized", "json"] // no other formats yet specified, but can be added!
   loadMentions = true
   mentionsFile = "/local/path/to/PT-mentions.json"
   appendToGrFN = true


### PR DESCRIPTION
@alicekwak 

if you run the ExtractAndExport app (the one I modified; use intellij or you can do it with `sbt run` and then enter the number for ExtractAndExport app, should be 4?), it will output a tsv file with some useful information (doc name, sentence, mention label and type + all args with text for that mention). Types of output (in this case .tsv) are defined in exportAs in application.conf. We normally use the json, but this tsv is more usuful for manual analysis. 

