### PR TITLE
Add mocked gromet experiment execution endpoint

### DIFF
--- a/automates/apps/automates/automates.py
+++ b/automates/apps/automates/automates.py
@@ -8,7 +8,10 @@ from automates.apps.automates.extract_driver import (
     extract_expr_trees_from_grfn_json,
     extract_model_dynamics_from_grfn_json,
 )
-from automates.apps.automates.execute_driver import execute_grfn_json
+from automates.apps.automates.execute_driver import (
+    execute_grfn_json,
+    execute_gromet_experiment_json,
+)
 
 # Create app and blueprint objects
 app = Flask(__name__)
@@ -111,6 +114,18 @@ def execute_grfn():
 
     execution_results = execute_grfn_json(grfn_json, input_json, outputs_json)
     return jsonify(execution_results)
+
+
+@bp_api_v1.route("/execute/gromet_experiment", methods=["POST"])
+def execute_gromet_experiment():
+    """
+
+    Returns:
+        [type]: [description]
+    """
+    experiment_json = request.json
+    experiment_results = execute_gromet_experiment_json(experiment_json)
+    return jsonify(experiment_results)
 
 
 # Register API blueprints

--- a/automates/apps/automates/execute_driver.py
+++ b/automates/apps/automates/execute_driver.py
@@ -1,6 +1,9 @@
 import numpy as np
+import json
 
 from automates.model_assembly.networks import GroundedFunctionNetwork, VariableNode
+import automates.apps.automates.model_code.chime_sir as chime
+import automates.apps.automates.model_code.sir_simple as sir_simple
 
 
 def parse_execution_inputs(inputs):
@@ -41,3 +44,144 @@ def execute_grfn_json(grfn_json, input_json, outputs_json):
         results.extend(gather_additional_outputs(outputs_json, GrFN))
 
     return results
+
+
+def collect_unknown_experiment_inputs(expected, given):
+    found_unknown_keys = list()
+    for input in expected:
+        if input not in given:
+            found_unknown_keys.append(input)
+    return found_unknown_keys
+
+
+def run_model_experiment(
+    name, start, end, step, expected_parameters, parameters, drive_fn
+):
+    found_unknown_keys = collect_unknown_experiment_inputs(
+        expected_parameters, parameters
+    )
+    if len(found_unknown_keys) > 0:
+        return {
+            "code": 400,
+            "error": f"Did not find expected parameters {found_unknown_keys} for model {name}.",
+        }
+
+    return drive_fn(start, end, step, parameters)
+
+
+def execute_gromet_experiment_json(experiment_json):
+    """
+    Expected input object:
+
+    {
+        "command": "simulate-gsl",
+        "definition": {
+            "type": "easel",
+            "source": "{ \"model\": \" GroMEt Model String \" }"
+        },
+        "start": 0,
+        "end": 120.0,
+        "step": 30.0,
+        "domain_parameter": "",
+        "parameters": {
+            "beta": 0.9
+        },
+        "outputs": [
+            "s",
+            "i",
+            "r"
+        ]
+    }
+
+    Args:
+        experiment_json (Dict): A python object reflecting the model above
+
+    Returns: results of gromet experiment execution
+    """
+
+    expected_keys = [
+        "definition",
+        "start",
+        "end",
+        "step",
+        "domain_parameter",
+        "parameters",
+        "outputs",
+    ]
+    not_found_keys = []
+    for key in expected_keys:
+        if key not in experiment_json:
+            not_found_keys.append(key)
+
+    if len(not_found_keys) > 0:
+        return {"code": 400, "message": f"Expected key(s) {not_found_keys} not found."}
+
+    start = None
+    end = None
+    step = None
+    try:
+        start = int(experiment_json["start"])
+        end = int(experiment_json["end"])
+        step = int(experiment_json["step"])
+    except:
+        return {
+            "code": 400,
+            "message": f'Unable to parse integer value provided for one of "start", "end", or "step".',
+        }
+
+    domain_parameter = experiment_json["domain_parameter"]
+    parameters = experiment_json["parameters"]
+    outputs = experiment_json["outputs"]
+    gromet_source_json_str = experiment_json["definition"]["source"]["model"]
+    gromet_obj = json.loads(gromet_source_json_str)
+    model_name = gromet_obj["name"]
+
+    results = {}
+    if model_name == "SIR-simple":
+        expected_sir_simple_inputs = ["S", "I", "R", "beta", "gamma"]
+        try:
+            results = run_model_experiment(
+                model_name,
+                start,
+                end,
+                step,
+                expected_sir_simple_inputs,
+                parameters,
+                sir_simple.drive,
+            )
+        except:
+            return {
+                "status": 500,
+                "message": f'Error: Encountered issue while executing experiment "{model_name}".',
+            }
+
+    elif model_name == "CHIME-SIR":
+        try:
+            expected_sir_simple_inputs = []
+            results = run_model_experiment(
+                model_name,
+                start,
+                end,
+                step,
+                expected_sir_simple_inputs,
+                parameters,
+                chime.drive,
+            )
+        except:
+            return {
+                "status": 500,
+                "message": f'Error: Encountered issue while executing experiment "{model_name}".',
+            }
+    else:
+        return {
+            "code": 400,
+            "message": f'Unable to run model experiment for "{model_name}".',
+        }
+
+    return {
+        "status": 200,
+        "body": {
+            "values": {k: v for k, v in results.items() if k in outputs},
+            "domain_parameter": results[domain_parameter],
+        },
+    }

--- a/automates/apps/automates/execute_driver.py
+++ b/automates/apps/automates/execute_driver.py
@@ -138,7 +138,13 @@ def execute_gromet_experiment_json(experiment_json):
 
     results = {}
     if model_name == "SIR-simple":
-        expected_sir_simple_inputs = ["S", "I", "R", "beta", "gamma"]
+        expected_sir_simple_inputs = [
+            "SIR-simple::SIR-simple::sir::0::--::s::0",
+            "SIR-simple::SIR-simple::sir::0::--::i::0",
+            "SIR-simple::SIR-simple::sir::0::--::r::0",
+            "SIR-simple::SIR-simple::sir::0::--::beta::0",
+            "SIR-simple::SIR-simple::sir::0::--::gamma::0",
+        ]
         try:
             results = run_model_experiment(
                 model_name,
@@ -156,8 +162,8 @@ def execute_gromet_experiment_json(experiment_json):
             }
 
     elif model_name == "CHIME-SIR":
+        expected_sir_simple_inputs = []
         try:
-            expected_sir_simple_inputs = []
             results = run_model_experiment(
                 model_name,
                 start,

--- a/automates/apps/automates/model_code/chime_sir.py
+++ b/automates/apps/automates/model_code/chime_sir.py
@@ -112,7 +112,8 @@ def execute(
 
 def drive(start, end, step, parameters):
 
-    (S, E, I, R) = execute(**parameters, n_days=end)
+    param_names_to_vals = {k.split("::")[-2]: v for k, v in parameters.items()}
+    (S, E, I, R) = execute(**param_names_to_vals, n_days=end)
 
     def process_time_step_results(result_arr):
         stepped_results = []
@@ -121,9 +122,11 @@ def drive(start, end, step, parameters):
         return stepped_results
 
     return {
-        "S": process_time_step_results(S),
-        "E": process_time_step_results(E),
-        "I": process_time_step_results(I),
-        "R": process_time_step_results(R),
-        "n_days": process_time_step_results(range(end + 1)),
+        "CHIME_SIR::CHIME_SIR::main::0::--::s_a::1": process_time_step_results(S),
+        "CHIME_SIR::CHIME_SIR::main::0::--::e_a::1": process_time_step_results(E),
+        "CHIME_SIR::CHIME_SIR::main::0::--::i_a::1": process_time_step_results(I),
+        "CHIME_SIR::CHIME_SIR::main::0::--::r_a::1": process_time_step_results(R),
+        "CHIME_SIR::CHIME_SIR::main::0::--::n_days::0": process_time_step_results(
+            range(end + 1)
+        ),
     }

--- a/automates/apps/automates/model_code/chime_sir.py
+++ b/automates/apps/automates/model_code/chime_sir.py
@@ -1,0 +1,129 @@
+def get_beta(intrinsic_growth_rate, gamma, susceptible, relative_contact_rate, beta):
+    inv_contact_rate = 1.0 - relative_contact_rate  # get_beta_icr_exp
+    updated_growth_rate = intrinsic_growth_rate + gamma  # get_beta_ugr_exp
+    beta = updated_growth_rate / susceptible * inv_contact_rate  # get_beta_beta_exp
+
+    return beta
+
+
+def get_growth_rate(doubling_time, growth_rate):
+    # ggr_cond
+    if doubling_time == 0:  # ggr_cond_b0_cond
+        growth_rate = 0  # ggr_cond_b0_exp
+    else:
+        growth_rate = 2.0 ** (1.0 / doubling_time) - 1.0  # ggr_cond_b1_exp
+
+    return growth_rate
+
+
+def sir(s, i, r, beta, gamma, n):
+    s_n = (-beta * s * i) + s  # sir_s_n_exp
+    i_n = (beta * s * i - gamma * i) + i  # sir_i_n_exp
+    r_n = gamma * i + r  # sir_r_n_exp
+
+    scale = n / (s_n + i_n + r_n)  # sir_scale_exp
+
+    s = s_n * scale  # sir_s_exp
+    i = i_n * scale  # sir_i_exp
+    r = r_n * scale  # sir_r_exp
+    return (s, i, r)
+
+
+def sim_sir(s_n, i_n, r_n, gamma, i_day, N_p, N_t, betas, days, T, S, E, I, R):
+
+    n = s_n + i_n + r_n  # simsir_n_exp
+    d = i_day  # simsir_d_exp
+
+    idx = 1  # simsir_idx_exp
+    for p_idx in range(N_p):  # simsir_loop_1
+        beta = betas[p_idx]  # simsir_loop_1_beta_exp
+        N_d = days[p_idx]  # simsir_loop_1_N_d_exp
+        for d_idx in range(N_d):  # simsir_loop_1_1
+            T[idx] = d  # simsir_loop_1_1_T_exp
+            S[idx] = s_n  # simsir_loop_1_1_S_exp
+            I[idx] = i_n  # simsir_loop_1_1_I_exp
+            R[idx] = r_n  # simsir_loop_1_1_R_exp
+            idx += 1  # simsir_loop_1_1_idx_exp
+            (s_n, i_n, r_n) = sir(
+                s_n, i_n, r_n, beta, gamma, n
+            )  # simsir_loop_1_1_call_sir_exp
+            d += 1  # simsir_loop_1_1_d_exp
+
+    T[idx] = d  # simsir_T_exp
+    S[idx] = s_n  # simsir_S_exp
+    I[idx] = i_n  # simsir_I_exp
+    R[idx] = r_n  # simsir_R_exp
+
+    return (s_n, i_n, r_n, E)
+
+
+def execute(
+    growth_rate=0.0,  # main_gr_exp
+    beta=0.0,  # main_beta_exp
+    i_day=17.0,  # main_i_day_exp
+    n_days=20,  # main_n_days_exp
+    N_p=3,  # main_N_p_exp
+    infections_days=14.0,  # main_inf_days_exp
+    relative_contact_rate=0.05,  # main_rcr_exp
+    s_n=1000,  # main_s_n_exp
+    i_n=1,  # main_i_n_exp
+    r_n=1,  # main_r_n_exp
+):
+    N_t = N_p * n_days + 2  # main_N_t_exp
+    gamma = 1.0 / infections_days  # main_gamma_exp
+
+    policys_betas = [0.0] * N_p  # TODO size      # main_pbetas_seq
+    policy_days = [0] * N_p  # main_pdays_seq
+    T = [0.0] * N_t  # main_T_seq
+    S = [0.0] * N_t  # main_S_seq
+    E = [0.0] * N_t  # main_E_seq
+    I = [0.0] * N_t  # main_I_seq
+    R = [0.0] * N_t  # main_R_seq
+
+    for p_idx in range(N_p):  # main_loop_1
+        doubling_time = (p_idx - 1.0) * 5.0  # main_loop_1_dtime_exp
+
+        growth_rate = get_growth_rate(doubling_time, growth_rate)  # main_loop_1_gr_exp
+        beta = get_beta(
+            growth_rate, gamma, s_n, relative_contact_rate, beta  # main_loop_1_beta_exp
+        )
+        policys_betas[p_idx] = beta  # main_loop_1_pbetas_exp
+        policy_days[p_idx] = n_days * p_idx  # main_loop_1_pdays_exp
+
+    (s_n, i_n, r_n, E) = sim_sir(
+        s_n,
+        i_n,
+        r_n,
+        gamma,
+        i_day,  # main_call_simsir_exp
+        N_p,
+        N_t,
+        policys_betas,
+        policy_days,
+        T,
+        S,
+        E,
+        I,
+        R,
+    )
+
+    return (S, E, I, R)
+
+
+def drive(start, end, step, parameters):
+
+    (S, E, I, R) = execute(**parameters, n_days=end)
+
+    def process_time_step_results(result_arr):
+        stepped_results = []
+        for i in range(start, end + 1, step):
+            stepped_results.append(result_arr[i])
+        return stepped_results
+
+    return {
+        "S": process_time_step_results(S),
+        "E": process_time_step_results(E),
+        "I": process_time_step_results(I),
+        "R": process_time_step_results(R),
+        "n_days": process_time_step_results(range(end + 1)),
+    }

--- a/automates/apps/automates/model_code/sir_simple.py
+++ b/automates/apps/automates/model_code/sir_simple.py
@@ -1,0 +1,75 @@
+def drive(start, end, step, parameters):
+    step_results = {"S": list(), "I": list(), "R": list(), "dt": list()}
+
+    for i in range(start, end + 1, step):
+        (S, I, R) = sir(
+            parameters["S"],
+            parameters["I"],
+            parameters["R"],
+            parameters["beta"],
+            parameters["gamma"],
+            i,
+        )
+
+        step_results["S"].append(S)
+        step_results["I"].append(I)
+        step_results["R"].append(R)
+        step_results["dt"].append(i)
+
+    return step_results
+
+
+"""
+Derived from the following:
+
+    ********************************************************************************
+    !     Input Variables:
+    !     S        Amount of susceptible members at the current timestep
+    !     I        Amount of infected members at the current timestep
+    !     R        Amount of recovered members at the current timestep
+    !     beta     Rate of transmission via contact
+    !     gamma    Rate of recovery from infection
+    !     dt       Next inter-event time
+    !
+    !     State Variables:
+    !     infected    Increase in infected at the current timestep
+    !     recovered   Increase in recovered at the current timestep
+    ********************************************************************************
+        subroutine sir(S, I, R, beta, gamma, dt)
+            implicit none
+            double precision S, I, R, beta, gamma, dt
+            double precision infected, recovered
+
+            infected = ((beta*S*I) / (S + I + R)) * dt
+            recovered = (gamma*I) * dt
+
+            S = S - infected
+            I = I + infected - recovered
+            R = R + recovered
+        end subroutine sir
+"""
+
+
+def sir(S: float, I: float, R: float, beta: float, gamma: float, dt: float):
+    """
+    !     Input Variables:
+    !     S        Amount of susceptible members at the current timestep
+    !     I        Amount of infected members at the current timestep
+    !     R        Amount of recovered members at the current timestep
+    !     beta     Rate of transmission via contact
+    !     gamma    Rate of recovery from infection
+    !     dt       Next inter-event time
+    !
+    !     State Variables:
+    !     infected    Increase in infected at the current timestep
+    !     recovered   Increase in recovered at the current timestep
+    """
+
+    infected = ((beta * S * I) / (S + I + R)) * dt
+    recovered = (gamma * I) * dt
+
+    S = S - infected
+    I = I + infected - recovered
+    R = R + recovered
+
+    return (S, I, R)

--- a/automates/apps/automates/model_code/sir_simple.py
+++ b/automates/apps/automates/model_code/sir_simple.py
@@ -1,20 +1,29 @@
 def drive(start, end, step, parameters):
-    step_results = {"S": list(), "I": list(), "R": list(), "dt": list()}
+    step_results = {
+        "SIR-simple::SIR-simple::sir::0::--::s::1": list(),
+        "SIR-simple::SIR-simple::sir::0::--::i::1": list(),
+        "SIR-simple::SIR-simple::sir::0::--::r::1": list(),
+        "SIR-simple::SIR-simple::sir::0::--::dt::0": list(),
+    }
+
+    S = parameters["SIR-simple::SIR-simple::sir::0::--::s::0"]
+    I = parameters["SIR-simple::SIR-simple::sir::0::--::i::0"]
+    R = parameters["SIR-simple::SIR-simple::sir::0::--::r::0"]
 
     for i in range(start, end + 1, step):
         (S, I, R) = sir(
-            parameters["S"],
-            parameters["I"],
-            parameters["R"],
-            parameters["beta"],
-            parameters["gamma"],
-            i,
+            S,
+            I,
+            R,
+            parameters["SIR-simple::SIR-simple::sir::0::--::beta::0"],
+            parameters["SIR-simple::SIR-simple::sir::0::--::gamma::0"],
+            step,
         )
 
-        step_results["S"].append(S)
-        step_results["I"].append(I)
-        step_results["R"].append(R)
-        step_results["dt"].append(i)
+        step_results["SIR-simple::SIR-simple::sir::0::--::s::1"].append(S)
+        step_results["SIR-simple::SIR-simple::sir::0::--::i::1"].append(I)
+        step_results["SIR-simple::SIR-simple::sir::0::--::r::1"].append(R)
+        step_results["SIR-simple::SIR-simple::sir::0::--::dt::0"].append(i)
 
     return step_results
 

--- a/tests/apps/automates/execution/test_gromet_experiment_execution.py
+++ b/tests/apps/automates/execution/test_gromet_experiment_execution.py
@@ -1,0 +1,86 @@
+from automates.apps.automates.execute_driver import execute_gromet_experiment_json
+
+
+def test_execute_sir_simple_mock():
+    input_json = {
+        "command": "simulate-gsl",
+        "definition": {"type": "easel", "source": {"model": '{"name": "SIR-simple"}'}},
+        "start": 0,
+        "end": 120.0,
+        "step": 30.0,
+        "domain_parameter": "dt",
+        "parameters": {"beta": 0.9, "S": 1, "I": 1, "R": 1, "gamma": 1},
+        "outputs": ["S", "I", "R"],
+    }
+    result = execute_gromet_experiment_json(input_json)
+
+    expected = {
+        "body": {
+            "domain_parameter": [0, 30, 60, 90, 120],
+            "values": {
+                "I": [1.0, -20.0, -41.0, -62.0, -83.0],
+                "R": [1, 31, 61, 91, 121],
+                "S": [1.0, -8.0, -17.0, -26.0, -35.0],
+            },
+        },
+        "status": 200,
+    }
+
+    assert expected == result
+
+
+def test_execute_chime_sir_mock():
+    input_json = {
+        "command": "simulate-gsl",
+        "definition": {"type": "easel", "source": {"model": '{"name": "CHIME-SIR"}'}},
+        "start": 0,
+        "end": 120.0,
+        "step": 30,
+        "domain_parameter": "n_days",
+        "parameters": {
+            "growth_rate": 0.0,
+            "beta": 0.0,
+            "i_day": 17.0,
+            "N_p": 3,
+            "infections_days": 14.0,
+            "relative_contact_rate": 0.05,
+            "s_n": 200,
+            "i_n": 1,
+            "r_n": 1,
+        },
+        "outputs": ["S", "I", "E", "R"],
+    }
+    result = execute_gromet_experiment_json(input_json)
+
+    expected = {
+        "body": {
+            "domain_parameter": [0, 30, 60, 90, 120],
+            "values": {
+                "E": [0.0, 0.0, 0.0, 0.0, 0.0],
+                "I": [
+                    0.0,
+                    0.8933233135653156,
+                    0.7806198884453974,
+                    0.6712711762750359,
+                    0.5693715755370689,
+                ],
+                "R": [
+                    0.0,
+                    2.965680650912271,
+                    4.763081925816063,
+                    6.3215644582752715,
+                    7.652866183157096,
+                ],
+                "S": [
+                    0.0,
+                    198.14099603552242,
+                    196.45629818573855,
+                    195.00716436544968,
+                    193.77776224130582,
+                ],
+            },
+        },
+        "status": 200,
+    }
+
+    assert result == expected

--- a/tests/apps/automates/execution/test_gromet_experiment_execution.py
+++ b/tests/apps/automates/execution/test_gromet_experiment_execution.py
@@ -8,9 +8,19 @@ def test_execute_sir_simple_mock():
         "start": 0,
         "end": 120.0,
         "step": 30.0,
-        "domain_parameter": "dt",
-        "parameters": {"beta": 0.9, "S": 1, "I": 1, "R": 1, "gamma": 1},
-        "outputs": ["S", "I", "R"],
+        "domain_parameter": "SIR-simple::SIR-simple::sir::0::--::dt::0",
+        "parameters": {
+            "SIR-simple::SIR-simple::sir::0::--::beta::0": 0.5,
+            "SIR-simple::SIR-simple::sir::0::--::s::0": 100000,
+            "SIR-simple::SIR-simple::sir::0::--::i::0": 1,
+            "SIR-simple::SIR-simple::sir::0::--::r::0": 0,
+            "SIR-simple::SIR-simple::sir::0::--::gamma::0": 0.07,
+        },
+        "outputs": [
+            "SIR-simple::SIR-simple::sir::0::--::s::1",
+            "SIR-simple::SIR-simple::sir::0::--::i::1",
+            "SIR-simple::SIR-simple::sir::0::--::r::1",
+        ],
     }
     result = execute_gromet_experiment_json(input_json)
 
@@ -18,9 +28,27 @@ def test_execute_sir_simple_mock():
         "body": {
             "domain_parameter": [0, 30, 60, 90, 120],
             "values": {
-                "I": [1.0, -20.0, -41.0, -62.0, -83.0],
-                "R": [1, 31, 61, 91, 121],
-                "S": [1.0, -8.0, -17.0, -26.0, -35.0],
+                "SIR-simple::SIR-simple::sir::0::--::i::1": [
+                    13.899850001499987,
+                    193.17455602717965,
+                    2678.622276802565,
+                    35981.04345749553,
+                    273225.5469052609,
+                ],
+                "SIR-simple::SIR-simple::sir::0::--::r::1": [
+                    2.1,
+                    31.289685003149977,
+                    436.9562526602273,
+                    6062.063033945615,
+                    81622.25429468622,
+                ],
+                "SIR-simple::SIR-simple::sir::0::--::s::1": [
+                    99985.0001499985,
+                    99776.53575896967,
+                    96885.4214705372,
+                    57957.893508558845,
+                    -254846.80119994713,
+                ],
             },
         },
         "status": 200,
@@ -36,19 +64,24 @@ def test_execute_chime_sir_mock():
         "start": 0,
         "end": 120.0,
         "step": 30,
-        "domain_parameter": "n_days",
+        "domain_parameter": "CHIME_SIR::CHIME_SIR::main::0::--::n_days::0",
         "parameters": {
-            "growth_rate": 0.0,
-            "beta": 0.0,
-            "i_day": 17.0,
-            "N_p": 3,
-            "infections_days": 14.0,
-            "relative_contact_rate": 0.05,
-            "s_n": 200,
-            "i_n": 1,
-            "r_n": 1,
+            "CHIME_SIR::CHIME_SIR::main::0::--::growth_rate::0": 0.0,
+            "CHIME_SIR::CHIME_SIR::main::0::--::beta::0": 0.0,
+            "CHIME_SIR::CHIME_SIR::main::0::--::i_day::0": 17.0,
+            "CHIME_SIR::CHIME_SIR::main::0::--::N_p::0": 3,
+            "CHIME_SIR::CHIME_SIR::main::0::--::infections_days::0": 14.0,
+            "CHIME_SIR::CHIME_SIR::main::0::--::relative_contact_rate::0": 0.05,
+            "CHIME_SIR::CHIME_SIR::main::0::--::s_n::0": 200,
+            "CHIME_SIR::CHIME_SIR::main::0::--::i_n::0": 1,
+            "CHIME_SIR::CHIME_SIR::main::0::--::r_n::0": 1,
         },
-        "outputs": ["S", "I", "E", "R"],
+        "outputs": [
+            "CHIME_SIR::CHIME_SIR::main::0::--::s_a::1",
+            "CHIME_SIR::CHIME_SIR::main::0::--::i_a::1",
+            "CHIME_SIR::CHIME_SIR::main::0::--::e_a::1",
+            "CHIME_SIR::CHIME_SIR::main::0::--::r_a::1",
+        ],
     }
     result = execute_gromet_experiment_json(input_json)
 
@@ -56,22 +89,22 @@ def test_execute_chime_sir_mock():
         "body": {
             "domain_parameter": [0, 30, 60, 90, 120],
             "values": {
-                "E": [0.0, 0.0, 0.0, 0.0, 0.0],
-                "I": [
+                "CHIME_SIR::CHIME_SIR::main::0::--::e_a::1": [0.0, 0.0, 0.0, 0.0, 0.0],
+                "CHIME_SIR::CHIME_SIR::main::0::--::i_a::1": [
                     0.0,
                     0.8933233135653156,
                     0.7806198884453974,
                     0.6712711762750359,
                     0.5693715755370689,
                 ],
-                "R": [
+                "CHIME_SIR::CHIME_SIR::main::0::--::r_a::1": [
                     0.0,
                     2.965680650912271,
                     4.763081925816063,
                     6.3215644582752715,
                     7.652866183157096,
                 ],
-                "S": [
+                "CHIME_SIR::CHIME_SIR::main::0::--::s_a::1": [
                     0.0,
                     198.14099603552242,
                     196.45629818573855,


### PR DESCRIPTION
Adds an endpoint to the automates app that mimics execution of a grommet experiment. It allows a user to give inputs and select outputs for CHIME-SIR and SIR-Simple grommets. 

When a particular gromet model is selected, the endpoint actually runs the python source code the gromet is generated from and returns the result.