### PR TITLE
Debugging test t3f

### DIFF
--- a/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinActions.scala
+++ b/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinActions.scala
@@ -40,12 +40,14 @@ class OdinActions(val taxonomy: Taxonomy, expansionHandler: Option[ExpansionHand
       val (descriptions, other) = (expandedIdentifiers ++ non_identifiers).partition(m => m.label.contains("Description"))
       val (functions, nonFunc) = other.partition(m => m.label.contains("Function"))
       val (modelDescrs, nonModelDescrs) = nonFunc.partition(m => m.label == "ModelDescr")
+
       // only expand concepts in param settings and units, not the identifier-looking variables (e.g., expand `temperature` in `temparature is set to 0`, but not `T` in `T is set to 0`)
       val (paramSettingsAndUnitsNoIdfr, nonExpandable) = nonModelDescrs.partition(m => (m.label.contains("ParameterSetting") || m.label.contains("UnitRelation")) && !m.arguments("variable").head.labels.contains("Identifier"))
 
       val expandedParamSettings = expansionHandler.get.expandArguments(paramSettingsAndUnitsNoIdfr, state, List("variable"))
 
       val expandedDescriptions = expansionHandler.get.expandArguments(descriptions, state, validArgs)
+
       val expandedFunction = expansionHandler.get.expandArguments(functions, state, List("input", "output"))
       val expandedModelDescrs = expansionHandler.get.expandArguments(modelDescrs, state, List("modelDescr"))
       val (conjDescrType2, otherDescrs) = expandedDescriptions.partition(_.label.contains("Type2"))
@@ -54,7 +56,6 @@ class OdinActions(val taxonomy: Taxonomy, expansionHandler: Option[ExpansionHand
 
       resolveCoref(keepOneWithSameSpanAfterExpansion(allDescrs) ++ expandedFunction ++ expandedParamSettings ++ expandedModelDescrs ++ nonExpandable)
       //      allDescrs ++ other
-
     } else {
       mentions
     }

--- a/automates/text_reading/src/main/scala/org/clulab/aske/automates/actions/ExpansionHandler.scala
+++ b/automates/text_reading/src/main/scala/org/clulab/aske/automates/actions/ExpansionHandler.scala
@@ -103,10 +103,18 @@ class ExpansionHandler() extends LazyLogging {
         for (argToExpand <- sortedClosestFirst) {
 //          println("arg to expand: " + argToExpand.text + " " + argToExpand.foundBy + " " + argToExpand.labels)
           val expanded = expandIfNotAvoid(argToExpand, ExpansionHandler.MAX_HOPS_EXPANDING, stateToAvoid, m, expansionType)
-//          println("expanded arg: " + expanded.text + " " + expanded.foundBy + " " + expanded.labels)
-          expandedArgs.append(expanded)
+          // sometimes, e.g., in model descriptions, we want to expand an argument that happens to be in identifier;
+          // identifiers should not be expanded;
+          // if we expanded an identifier, it's probably not a stand-alone identifier anymore, so drop the Identifier label (it is normally the first one of the labels)
+          val expandedWithIdentifierLabelDropped = if (expanded.label == "Identifier") {
+            expanded.asInstanceOf[TextBoundMention].copy(expanded.labels.drop(1))
+          } else {
+            expanded
+          }
+//          println("expanded arg: " + expandedWithIdentifierLabelDropped.text + " " + expandedWithIdentifierLabelDropped.foundBy + " " + expandedWithIdentifierLabelDropped.label + "|" + expandedWithIdentifierLabelDropped.labels.mkString("::"))
+          expandedArgs.append(expandedWithIdentifierLabelDropped)
           // Add the mention to the ones to avoid so we don't suck it up
-          stateToAvoid = stateToAvoid.updated(Seq(expanded))
+          stateToAvoid = stateToAvoid.updated(Seq(expandedWithIdentifierLabelDropped))
         }
         // Handle attachments
         // todo: here we aren't really using attachments, but we can add them back in as needed
@@ -136,13 +144,10 @@ class ExpansionHandler() extends LazyLogging {
   // we should perhaps revisit this
   def expandIfNotAvoid(orig: Mention, maxHops: Int, stateToAvoid: State, m: Mention, expansionType: String): Mention = {
 
-//    println("ORIGINAL: " + orig.text + " " + orig.labels + " " + orig.foundBy)
     val expanded = orig match {
-      case tbm: TextBoundMention => expand(orig, maxHops = ExpansionHandler.MAX_HOPS_EXPANDING, maxHopLength = ExpansionHandler.MAX_HOP_LENGTH, stateToAvoid, expansionType)
+      case tbm: TextBoundMention => expand(tbm, maxHops = ExpansionHandler.MAX_HOPS_EXPANDING, maxHopLength = ExpansionHandler.MAX_HOP_LENGTH, stateToAvoid, expansionType)
       case _ => orig
     }
-
-//    println("EXPANDED: " + expanded.text + " " + expanded.labels + " " + expanded.foundBy)
     //println(s"orig: ${orig.text}\texpanded: ${expanded.text}")
 
     // split expanded at trigger (only thing in state to avoid)
@@ -441,7 +446,7 @@ class ExpansionHandler() extends LazyLogging {
 }
 
 object ExpansionHandler {
-  val MAX_HOPS_EXPANDING = 0
+  val MAX_HOPS_EXPANDING = 5
   val MAX_HOP_LENGTH = 16 //max length of hop (in tokens); helps with bad parses
   val AVOID_LABEL = "Avoid-Strict"
 
@@ -529,6 +534,7 @@ object ExpansionHandler {
     "^conj".r,
     "cop".r,
     "dep".r, //todo: expansion on dep is freq too broad; check which tests fail if dep is included as invalid outgoing,
+    "det".r,
     "nmod_at".r,
     "nmod_through".r,
     "^nmod_as".r,

--- a/automates/text_reading/src/main/scala/org/clulab/aske/automates/serializer/AutomatesSerializer.scala
+++ b/automates/text_reading/src/main/scala/org/clulab/aske/automates/serializer/AutomatesSerializer.scala
@@ -27,9 +27,7 @@ object AutomatesJSONSerializer {
 
     val docMap = mkDocumentMap(menUJson("documents"))
     val mentionsUJson = menUJson("mentions")
-    val toReturn = mentionsUJson.arr.map(item => toMention(item, docMap)).toSeq
-    toReturn
-
+    mentionsUJson.arr.map(item => toMention(item, docMap)).toSeq
   }
 
 
@@ -173,7 +171,6 @@ object AutomatesJSONSerializer {
 
   def toAttachment(json: ujson.Value): Attachment = {
     val attType = json("attType").str
-    val foundBy = json("foundBy").str
     val toReturn = attType match {
       case "MentionLocation" => new MentionLocationAttachment(json("pageNum").num.toInt, json("blockIdx").num.toInt, attType)
       case "DiscontinuousCharOffset" => new DiscontinuousCharOffsetAttachment(json("charOffsets").arr.map(v => (v.arr.head.num.toInt, v.arr.last.num.toInt)), attType)

--- a/automates/text_reading/src/main/scala/org/clulab/utils/AlignmentUtils.scala
+++ b/automates/text_reading/src/main/scala/org/clulab/utils/AlignmentUtils.scala
@@ -80,7 +80,6 @@ object AlignmentJsonUtils {
       Some(textMentions)
     } else None
 
-
     val descriptionMentions = if (allMentions.nonEmpty) {
       Some(allMentions
         .get

--- a/automates/text_reading/src/test/scala/org/clulab/aske/automates/alignment/TestAlign.scala
+++ b/automates/text_reading/src/test/scala/org/clulab/aske/automates/alignment/TestAlign.scala
@@ -49,7 +49,6 @@ class TestAlign extends TestAlignment {
 
   val argsForGrounding: AlignmentArguments = AlignmentJsonUtils.getArgsForAlignment(payloadPath, jsonObj, groundToSVO, groundToWiki, serializerName)
 
-
   val groundings: ujson.Value = ExtractAndAlign.groundMentions(
     payloadJson,
     argsForGrounding.identifierNames,


### PR DESCRIPTION
main change: drop Identifier label on an expanded Identifier mention---it is no longer just an identifier if we expand---this was what broke test t3f

other:
- added det to invalid outgoing to one of new invalid outgoings---it was expanding to just the determiner;
- set hops back to five; 
- remove 'foundBy' in toAttachment---key was not found because foundBy does not occur in all types of attachments, which broke align test 