### PR TITLE
Unit and param men fix dec2021

### DIFF
--- a/automates/text_reading/src/main/resources/org/clulab/aske_automates/grammars/taxonomy.yml
+++ b/automates/text_reading/src/main/resources/org/clulab/aske_automates/grammars/taxonomy.yml
@@ -11,8 +11,7 @@
       - CommLineParameter
       - Measurement:
         - Value
-        - Unit:
-          - UnitRelation
+        - Unit
       - Filename
       - Language
       - Repository
@@ -37,3 +36,4 @@
   - Context
   - CommandSequence
   - MD_Context
+  - UnitRelation

--- a/automates/text_reading/src/main/resources/org/clulab/aske_automates/grammars/taxonomy.yml
+++ b/automates/text_reading/src/main/resources/org/clulab/aske_automates/grammars/taxonomy.yml
@@ -10,8 +10,7 @@
       - Parameter
       - CommLineParameter
       - Measurement:
-        - Value:
-          - ValueAndUnit
+        - Value
         - Unit:
           - UnitRelation
       - Filename

--- a/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinActions.scala
+++ b/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinActions.scala
@@ -578,7 +578,7 @@ class OdinActions(val taxonomy: Taxonomy, expansionHandler: Option[ExpansionHand
         }
       }
     }
-    toReturn.distinct ++ noVar
+    toReturn.filter(_.arguments("variable").length == 1).distinct ++ noVar
   }
 
   def processCommands(mentions: Seq[Mention], state: State = new State()): Seq[Mention] = {

--- a/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
+++ b/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
@@ -81,7 +81,7 @@ class OdinEngine(
     // println(s"In extractFrom() -- res : ${initialState.allMentions.map(m => m.text).mkString(",\t")}")
 
     // Run the main extraction engine, pre-populated with the initial state
-    val events = actions.processCommands(  engine.extractFrom(doc, initialState).toVector)
+    val events = actions.processCommands(engine.extractFrom(doc, initialState).toVector)
     val (paramSettings, nonParamSettings) = events.partition(_.label.contains("ParameterSetting")) // `paramSettings` includes interval param setting
     val noOverlapParamSettings = actions.intervalParamSettTakesPrecedence(paramSettings)
     val paramSettingsAndOthers = noOverlapParamSettings ++ nonParamSettings

--- a/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
+++ b/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
@@ -82,8 +82,11 @@ class OdinEngine(
 
     // Run the main extraction engine, pre-populated with the initial state
     val events = actions.processCommands(actions.assembleVarsWithParamsAndUnits(  engine.extractFrom(doc, initialState)).toVector)
-    val newModelParams1 = actions.paramSettingVarToModelParam(events)
-    val modelCorefResolve = actions.resolveModelCoref(events)
+    val (paramSettings, nonParamSettings) = events.partition(_.label.contains("ParameterSetting")) // `paramSettings` includes interval param setting
+    val noOverlapParamSettings = actions.intervalParamSettTakesPrecedence(paramSettings)
+    val paramSettingsAndOthers = noOverlapParamSettings ++ nonParamSettings
+    val newModelParams1 = actions.paramSettingVarToModelParam(paramSettingsAndOthers)
+    val modelCorefResolve = actions.resolveModelCoref(paramSettingsAndOthers)
 
     // process context attachments to the initially extracted mentions
     val newEventsWithContexts = actions.makeNewMensWithContexts(modelCorefResolve)

--- a/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
+++ b/automates/text_reading/src/main/scala/org/clulab/aske/automates/OdinEngine.scala
@@ -81,7 +81,7 @@ class OdinEngine(
     // println(s"In extractFrom() -- res : ${initialState.allMentions.map(m => m.text).mkString(",\t")}")
 
     // Run the main extraction engine, pre-populated with the initial state
-    val events = actions.processCommands(actions.assembleVarsWithParamsAndUnits(  engine.extractFrom(doc, initialState)).toVector)
+    val events = actions.processCommands(  engine.extractFrom(doc, initialState).toVector)
     val (paramSettings, nonParamSettings) = events.partition(_.label.contains("ParameterSetting")) // `paramSettings` includes interval param setting
     val noOverlapParamSettings = actions.intervalParamSettTakesPrecedence(paramSettings)
     val paramSettingsAndOthers = noOverlapParamSettings ++ nonParamSettings
@@ -106,7 +106,7 @@ class OdinEngine(
     val finalModelDescrs = modelDescrs.filter(_.arguments.contains("modelName"))
     val finalModelParam = actions.filterModelParam(newModelParams1 ++ newModelParams2)
 
-    actions.replaceWithLongerIdentifier(actions.keepLongest(other ++ combining ++ modelFilter ++ finalModelParam  ++ finalModelDescrs) ++ untangled).toVector.distinct
+    actions.assembleVarsWithParamsAndUnits(actions.replaceWithLongerIdentifier(actions.keepLongest(other ++ combining ++ modelFilter ++ finalModelParam  ++ finalModelDescrs) ++ untangled)).toVector.distinct
 
   }
 

--- a/automates/text_reading/src/test/scala/org/clulab/aske/automates/text/TestParameterSetting.scala
+++ b/automates/text_reading/src/test/scala/org/clulab/aske/automates/text/TestParameterSetting.scala
@@ -257,7 +257,7 @@ class TestParameterSetting  extends ExtractionTest {
   val u5a = "For the purposes of model parameterisation the value of shoot_lag has been assumed to be around 40 o Cd."
   passingTest should s"extract the parameter setting(s) from u5a: ${u5a}" taggedAs(Somebody) in {
     val desired = Seq(
-      "shoot_lag" -> Seq("40")
+      "value of shoot_lag" -> Seq("40")
     )
     val mentions = extractMentions(u5a)
     testParameterSettingEvent(mentions, desired)


### PR DESCRIPTION
- remove param setting mentions if there are more complete, overlapping interval param settings 
- disallow ParamAndUnit mentions that have more than one identifier (each mention should be associated with only one identifier)
- added a copyWithFoundBy method (for easier labeling of mentions with actions involved in their creation), e.g., here, the mention has been produced by the `var-word-equals_value-token` and the `assembleVarsWithParamsAndUnits` action:
```
List(ParamAndUnit, Event) => refugee move speed is equal to 200 
     ------------------------------ 
     Rule => var-word-equals_value-token++assembleVarsWithParamsAndUnits 
     Type => RelationMention 
     ------------------------------ 
     value (Value, Measurement, Phrase, Entity) => 200 
     unit (Unit, Measurement, Phrase, Entity) => km per day 
     variable (Phrase, Entity) => refugee move speed 
```
- removed ValueAndUnit (not being used)