### PR TITLE
Null code_span metadata GrFN generation

### DIFF
--- a/automates/model_assembly/metadata.py
+++ b/automates/model_assembly/metadata.py
@@ -297,7 +297,10 @@ class CodeSpan(BaseMetadata):
 
     @classmethod
     def from_data(cls, data: dict) -> CodeSpan:
-        return cls(**data)
+        if data == {} or data is None:
+            return None
+        else:
+            return cls(**data)
 
     def to_dict(self):
         return {


### PR DESCRIPTION
Added a small check in metadata.py that checks whether the input GrFN has no code_span metadata information. This is to allow GrFNs to be executed on the web API and to have their expression trees extracted in the case they have no code_span information. 