### PR TITLE
GrFN Omit Sources Toggle Flag

### DIFF
--- a/automates/model_assembly/networks.py
+++ b/automates/model_assembly/networks.py
@@ -1010,7 +1010,7 @@ class GroundedFunctionNetwork(nx.DiGraph):
         self.lambdas = [n for n in self.nodes if isinstance(n, LambdaNode)]
         self.types = T
 
-        self.source_info = False # Boolean flag that determines whether or not we generate source reference information for the GrFN
+        self.omit_source_info = False # Boolean flag that determines whether or not we generate source reference information for the GrFN
 
         # NOTE: removing detached variables from GrFN
         del_indices = list()
@@ -1762,59 +1762,46 @@ class GroundedFunctionNetwork(nx.DiGraph):
             ],
             "metadata": [m.to_dict() for m in self.metadata],
         }
-        #if self.source_info:
-        for v in data["variables"]:
-            for e in v["metadata"]:
-                if e["type"] == "code_span_reference":
-                    e["code_span"] = None
+        if self.omit_source_info:
+            for v in data["variables"]:
+                for e in v["metadata"]:
+                    if e["type"] == "code_span_reference":
+                        e["code_span"] = None
 
-        for v in data["functions"]:
-            for e in v["metadata"]:
-                if e["type"] == "code_span_reference":
-                    e["code_span"] = None
+            for v in data["functions"]:
+                for e in v["metadata"]:
+                    if e["type"] == "code_span_reference":
+                        e["code_span"] = None
 
-        for v in data["subgraphs"]:
-            for e in v["metadata"]:
-                if e["type"] == "code_span_reference":
-                    e["code_span"] = None
+            for v in data["subgraphs"]:
+                for e in v["metadata"]:
+                    if e["type"] == "code_span_reference":
+                        e["code_span"] = None
 
-        for v in data["types"]:
-            for e in v["metadata"]:
-                if e["type"] == "code_span_reference":
-                    e["code_span"] = None
+            for v in data["types"]:
+                for e in v["metadata"]:
+                    if e["type"] == "code_span_reference":
+                        e["code_span"] = None
 
-        for v in data["metadata"]:
-            for e in v["metadata"]:
-                if e["type"] == "code_span_reference":
-                    e["code_span"] = None
-
-        for v in data["variables"]:
-            v["metadata"] = None
-       #         if e["type"] == "code_span_reference":
-        #            e["code_span"] = None
-
-        for v in data["functions"]:
-            v["metadata"] = None
-#                if e["type"] == "code_span_reference":
- #                   e["code_span"] = None
-
-        for v in data["subgraphs"]:
-            v["metadata"] = None
-#                if e["type"] == "code_span_reference":
- #                   e["code_span"] = None
-
-        for v in data["types"]:
-            v["metadata"] = None
-#                if e["type"] == "code_span_reference":
- #                   e["code_span"] = None
-
-        for v in data["metadata"]:
-            v["metadata"] = None
-#                if e["type"] == "code_span_reference":
- #                   e["code_span"] = None
-
+            for v in data["metadata"]:
+                for e in v["metadata"]:
+                    if e["type"] == "code_span_reference":
+                        e["code_span"] = None
 
         return data
+
+    def set_source_flag(self, flag):
+        """Toggles a flag in the GrFN object that tells us whether or not we need to omit the source reference
+            information in the GrFN JSON. At the moment the source reference information is the 'code_span' information.
+            By default the source_info flag is set to False, 
+
+        Args:
+            flag (Boolean): Flag is set to either True or False depending on whether or not we want
+                            the source information to be removed (True) or kept (False)
+        """
+
+        self.omit_source_info = flag
+
 
     def to_json(self) -> str:
         """Outputs the contents of this GrFN to a JSON object string.

--- a/automates/model_assembly/networks.py
+++ b/automates/model_assembly/networks.py
@@ -1010,6 +1010,8 @@ class GroundedFunctionNetwork(nx.DiGraph):
         self.lambdas = [n for n in self.nodes if isinstance(n, LambdaNode)]
         self.types = T
 
+        self.source_info = False # Boolean flag that determines whether or not we generate source reference information for the GrFN
+
         # NOTE: removing detached variables from GrFN
         del_indices = list()
         for idx, var_node in enumerate(self.variables):
@@ -1741,7 +1743,7 @@ class GroundedFunctionNetwork(nx.DiGraph):
         :rtype: type
         :raises ExceptionName: Why the exception is raised.
         """
-        return {
+        data = {
             "uid": self.uid,
             "entry_point": "::".join(
                 ["@container", self.namespace, self.scope, self.name]
@@ -1760,6 +1762,59 @@ class GroundedFunctionNetwork(nx.DiGraph):
             ],
             "metadata": [m.to_dict() for m in self.metadata],
         }
+        #if self.source_info:
+        for v in data["variables"]:
+            for e in v["metadata"]:
+                if e["type"] == "code_span_reference":
+                    e["code_span"] = None
+
+        for v in data["functions"]:
+            for e in v["metadata"]:
+                if e["type"] == "code_span_reference":
+                    e["code_span"] = None
+
+        for v in data["subgraphs"]:
+            for e in v["metadata"]:
+                if e["type"] == "code_span_reference":
+                    e["code_span"] = None
+
+        for v in data["types"]:
+            for e in v["metadata"]:
+                if e["type"] == "code_span_reference":
+                    e["code_span"] = None
+
+        for v in data["metadata"]:
+            for e in v["metadata"]:
+                if e["type"] == "code_span_reference":
+                    e["code_span"] = None
+
+        for v in data["variables"]:
+            v["metadata"] = None
+       #         if e["type"] == "code_span_reference":
+        #            e["code_span"] = None
+
+        for v in data["functions"]:
+            v["metadata"] = None
+#                if e["type"] == "code_span_reference":
+ #                   e["code_span"] = None
+
+        for v in data["subgraphs"]:
+            v["metadata"] = None
+#                if e["type"] == "code_span_reference":
+ #                   e["code_span"] = None
+
+        for v in data["types"]:
+            v["metadata"] = None
+#                if e["type"] == "code_span_reference":
+ #                   e["code_span"] = None
+
+        for v in data["metadata"]:
+            v["metadata"] = None
+#                if e["type"] == "code_span_reference":
+ #                   e["code_span"] = None
+
+
+        return data
 
     def to_json(self) -> str:
         """Outputs the contents of this GrFN to a JSON object string.

--- a/automates/program_analysis/CAST2GrFN/cast.py
+++ b/automates/program_analysis/CAST2GrFN/cast.py
@@ -181,7 +181,7 @@ class CAST(object):
 
         return AutoMATES_IR(GenericIdentifier.from_str(air["entrypoint"]), C, V, T, [], [], [])
 
-    def to_GrFN(self):
+    def to_GrFN(self,source_ref):
         air = self.to_AIR()
         grfn = GroundedFunctionNetwork.from_AIR(air)
         return grfn

--- a/automates/program_analysis/CAST2GrFN/cast.py
+++ b/automates/program_analysis/CAST2GrFN/cast.py
@@ -181,9 +181,11 @@ class CAST(object):
 
         return AutoMATES_IR(GenericIdentifier.from_str(air["entrypoint"]), C, V, T, [], [], [])
 
-    def to_GrFN(self,source_ref):
+    def to_GrFN(self,omit_source_ref=False):
         air = self.to_AIR()
         grfn = GroundedFunctionNetwork.from_AIR(air)
+        if omit_source_ref:
+            grfn.set_source_flag(omit_source_ref)
         return grfn
 
     def write_cast_object(self, cast_value):

--- a/scripts/program_analysis/run_gcc_to_grfn.py
+++ b/scripts/program_analysis/run_gcc_to_grfn.py
@@ -46,6 +46,8 @@ def get_args(args=sys.argv[1:]):
     parser.add_argument("-p", "--plugin", help="Custom path to gcc plugin")
     parser.add_argument("-Cg", "--CASTgraph", help="Create CAST graphviz pdf",
             action='store_true')
+    parser.add_argument("-S", "--source", help="Turns off source reference information in the GrFN",
+            action='store_true')
     options = parser.parse_args(args)
     return options
 
@@ -145,7 +147,10 @@ def run_gcc_pipeline():
     # Set random seed to 0 for UUID generation for consistent results in
     # GrFN generation for tests
     misc.rd.seed(0)
-    grfn = cast.to_GrFN()
+    if args.source:
+        grfn = cast.to_GrFN(source_ref=False)
+    else:
+        grfn = cast.to_GrFN(source_ref=True)
     grfn.to_json_file(f"{program_name}--GrFN.json")
 
     print("Transforming GrFN into AGraph...")

--- a/scripts/program_analysis/run_gcc_to_grfn.py
+++ b/scripts/program_analysis/run_gcc_to_grfn.py
@@ -148,9 +148,9 @@ def run_gcc_pipeline():
     # GrFN generation for tests
     misc.rd.seed(0)
     if args.source:
-        grfn = cast.to_GrFN(source_ref=False)
+        grfn = cast.to_GrFN(omit_source_ref=True)
     else:
-        grfn = cast.to_GrFN(source_ref=True)
+        grfn = cast.to_GrFN(omit_source_ref=False)
     grfn.to_json_file(f"{program_name}--GrFN.json")
 
     print("Transforming GrFN into AGraph...")


### PR DESCRIPTION
Modified the GrFN data structure to allow it to have a toggle that determines whether or not the source reference information is included in the GrFN JSON. The source reference information is removed before the GrFN dictionary gets converted to JSON. An additional flag is added to 'run_gcc_to_grfn.py' that allows control of the toggle.