### PR TITLE
Added FromSource metadata to GrFN, fixed 3.0 FunctionDef containers 

### DIFF
--- a/automates/model_assembly/metadata.py
+++ b/automates/model_assembly/metadata.py
@@ -461,6 +461,15 @@ class VariableFromSource(TypedMetadata):
             VariableCreationReason.from_str(data["creation_reason"]),
         )
 
+    @classmethod
+    def from_ann_cast_data(cls, data: dict) -> VariableFromSource:
+        return cls(
+            data["type"],
+            data["provenance"],
+            data["from_source"] or data["from_source"] == "True",
+            data["creation_reason"],
+        )
+
     def to_dict(self):
         data = super().to_dict()
         data.update(

--- a/automates/model_assembly/networks.py
+++ b/automates/model_assembly/networks.py
@@ -1489,13 +1489,19 @@ class GroundedFunctionNetwork(nx.DiGraph):
 
     def to_FCG(self):
         G = nx.DiGraph()
-        func_to_func_edges = [
-            (func_node, node)
-            for node in self.nodes
-            if isinstance(node, LambdaNode)
-            for var_node in self.predecessors(node)
-            for func_node in self.predecessors(var_node)
-        ]
+        func_to_func_edges = []
+        for node in self.nodes:
+            if isinstance(node, LambdaNode):
+                preds = list(self.predecessors(node))
+                # DEBUGGING
+                # print(f"node {node} has predecessors {preds}")
+                for var_node in self.predecessors(node):
+                    preds = list(self.predecessors(var_node))
+                    # DEBUGGING
+                    # print(f"node {var_node} has predecessors {preds}")
+                    for func_node in self.predecessors(var_node):
+                        func_to_func_edges.append((func_node, node))
+                        
         G.add_edges_from(func_to_func_edges)
         return G
 


### PR DESCRIPTION
- Added metadata for variables introduced for interfaces, return values, arguments, and conditionals
- After adding metadata, we adjusted aliasing of GrFN variables.
- Fixed bug with FunctionDef argument ids in top interface.  This resolves an issue for GrFN generation for 3.0 FunctionDef containers