### PR TITLE
AnnCast-To-GrFN: Updates for 2.3 FunctionDefs/Calls and General Fixes

### DIFF
--- a/automates/model_assembly/metadata.py
+++ b/automates/model_assembly/metadata.py
@@ -425,6 +425,13 @@ class VariableCreationReason(AutoMATESBaseEnum):
     CONDITION_RESULT = auto()
     LOOP_EXIT_VAR = auto()
     LITERAL_FUNCTION_ARG = auto()
+    TOP_IFACE_INTRO = auto()
+    BOT_IFACE_INTRO = auto()
+    FUNC_RET_VAL = auto()
+    FUNC_ARG = auto()
+    COND_VAR = auto()
+    DUP_GLOBAL = auto()
+    DUMMY_ASSIGN = auto()
 
     def __str__(self):
         return str(self.name)

--- a/automates/model_assembly/networks.py
+++ b/automates/model_assembly/networks.py
@@ -338,10 +338,7 @@ class LambdaNode(GenericNode):
             "metadata": [m.to_dict() for m in self.metadata],
         }
 
-# TODO: make a subclass of LambdaNode for LoopTopInterface which includes
-# a use_initial boolean attribute and overwrite the parse_result() method
-# TODO: use this in to_grfn_pass.py when the loop top interface is created
-@dataclass
+@dataclass(eq=False)
 class LoopTopInterface(LambdaNode):
     use_initial: bool = False
 
@@ -1494,11 +1491,11 @@ class GroundedFunctionNetwork(nx.DiGraph):
             if isinstance(node, LambdaNode):
                 preds = list(self.predecessors(node))
                 # DEBUGGING
-                print(f"node {node} has predecessors {preds}")
+                # print(f"node {node} has predecessors {preds}")
                 for var_node in self.predecessors(node):
                     preds = list(self.predecessors(var_node))
                     # DEBUGGING
-                    print(f"node {var_node} has predecessors {preds}")
+                    # print(f"node {var_node} has predecessors {preds}")
                     for func_node in self.predecessors(var_node):
                         func_to_func_edges.append((func_node, node))
                         

--- a/automates/model_assembly/networks.py
+++ b/automates/model_assembly/networks.py
@@ -1494,11 +1494,11 @@ class GroundedFunctionNetwork(nx.DiGraph):
             if isinstance(node, LambdaNode):
                 preds = list(self.predecessors(node))
                 # DEBUGGING
-                # print(f"node {node} has predecessors {preds}")
+                print(f"node {node} has predecessors {preds}")
                 for var_node in self.predecessors(node):
                     preds = list(self.predecessors(var_node))
                     # DEBUGGING
-                    # print(f"node {var_node} has predecessors {preds}")
+                    print(f"node {var_node} has predecessors {preds}")
                     for func_node in self.predecessors(var_node):
                         func_to_func_edges.append((func_node, node))
                         
@@ -1532,8 +1532,10 @@ class GroundedFunctionNetwork(nx.DiGraph):
                         else dist
                     )
                     if func not in visited_funcs:
-                        new_successors.extend(self.FCG.successors(func))
                         visited_funcs.add(func)
+                        # add new successors if func is in FCG
+                        if func in self.FCG:
+                            new_successors.extend(self.FCG.successors(func))
 
                 if len(new_successors) > 0:
                     all_successors.extend(new_successors)

--- a/automates/program_analysis/CAST2GrFN/ann_cast/annotated_cast.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/annotated_cast.py
@@ -555,6 +555,8 @@ class AnnCast:
         self.collapsed_id_counter = 0
         # dict mapping FunctionDef container scopestr to its id
         self.func_con_scopestr_to_id = {}
+        # dict mapping container scope strings to their nodes
+        self.cont_scopestr_to_node = {}
         # dict mapping function IDs to their FunctionDef nodes.  
         self.func_id_to_def = {}
         self.grfn_id_to_grfn_var = {}

--- a/automates/program_analysis/CAST2GrFN/ann_cast/annotated_cast.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/annotated_cast.py
@@ -52,7 +52,7 @@ from automates.model_assembly.networks import (
     GroundedFunctionNetwork
 )
 
-GENERATE_GRFN_2_2 = True
+GENERATE_GRFN_2_2 = False
 
 # used in ContainerScopePass functions `con_scope_to_str()` and `visit_name()`
 CON_STR_SEP = "."

--- a/automates/program_analysis/CAST2GrFN/ann_cast/annotated_cast.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/annotated_cast.py
@@ -556,7 +556,7 @@ class AnnCast:
         # dict mapping FunctionDef container scopestr to its id
         self.func_con_scopestr_to_id = {}
         # dict mapping container scope strings to their nodes
-        self.cont_scopestr_to_node = {}
+        self.con_scopestr_to_node = {}
         # dict mapping function IDs to their FunctionDef nodes.  
         self.func_id_to_def = {}
         self.grfn_id_to_grfn_var = {}
@@ -568,15 +568,30 @@ class AnnCast:
         # GrFN stored after ToGrfnPass
         self.grfn: typing.Optional[GroundedFunctionNetwork] = None
 
+    def is_container(self, scopestr: str): 
+        """ 
+        Check if scopestr is a container scopestr
+        """
+        return scopestr in self.con_scopestr_to_node
+
+    def con_node_from_scopestr(self, scopestr: str):
+        """
+        Precondition: scopestr is a container scopestr
+        Return the container node associated with scopestr
+        """
+        return self.con_scopestr_to_node[scopestr]
+
     def get_grfn(self) -> typing.Optional[GroundedFunctionNetwork]:
         return self.grfn
-
 
     def func_def_exists(self, id: int) -> bool:
         """
         Check if there is a FuncionDef for id
         """
         return id in self.func_id_to_def
+
+    def is_con_scopestr_func_def(self, con_scopestr: str):
+        return con_scopestr in  self.func_con_scopestr_to_id
 
     def func_def_node_from_scopestr(self, con_scopestr: str):
         """
@@ -712,8 +727,8 @@ class AnnCastCall(AnnCastNode):
         self.bot_interface_in = {}
         self.bot_interface_out = {}
         # dicts mapping Name id to Name string
-        self.top_interface_globals = {}
-        self.bot_interface_globals = {}
+        self.top_interface_vars = {}
+        self.bot_interface_vars = {}
         # GrFN lambda expressions
         self.top_interface_lambda: str
         self.bot_interface_lambda: str
@@ -833,8 +848,10 @@ class AnnCastFunctionDef(AnnCastNode):
         self.modified_vars: typing.Dict[int, str]
         self.vars_accessed_before_mod: typing.Dict[int, str]
         self.used_vars: typing.Dict[int, str]
-        self.top_interface_globals: typing.Dict[int, str]
-        self.bot_interface_globals: typing.Dict[int, str]
+        # for now, top_interface_vars and bot_interface_vars only include globals
+        # since those variables cross the container boundaries
+        self.top_interface_vars: typing.Dict[int, str] = {}
+        self.bot_interface_vars: typing.Dict[int, str] = {}
         # dicts for global variables
         # for top_interface_out
         # mapping Name id to fullid
@@ -907,9 +924,9 @@ class AnnCastLoop(AnnCastNode):
         self.modified_vars: typing.Dict[int, str]
         self.vars_accessed_before_mod: typing.Dict[int, str]
         self.used_vars: typing.Dict[int, str]
-        self.top_interface_vars: typing.Dict[int, str]
-        self.top_interface_updated_vars: typing.Dict[int, str]
-        self.bot_interface_vars: typing.Dict[int, str]
+        self.top_interface_vars: typing.Dict[int, str] = {}
+        self.top_interface_updated_vars: typing.Dict[int, str] = {}
+        self.bot_interface_vars: typing.Dict[int, str] = {}
 
         # dicts mapping Name id to highest version at end of "block"
         self.expr_highest_var_vers = {}
@@ -986,8 +1003,8 @@ class AnnCastModelIf(AnnCastNode):
         self.modified_vars: typing.Dict[int, str]
         self.vars_accessed_before_mod: typing.Dict[int, str]
         self.used_vars: typing.Dict[int, str]
-        self.top_interface_vars: typing.Dict[int, str]
-        self.bot_interface_vars: typing.Dict[int, str]
+        self.top_interface_vars: typing.Dict[int, str] = {}
+        self.bot_interface_vars: typing.Dict[int, str] = {}
         # dicts mapping a Name id to variable string name
         # for variables used in the if expr
         self.expr_vars_accessed_before_mod = {}

--- a/automates/program_analysis/CAST2GrFN/ann_cast/annotated_cast.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/annotated_cast.py
@@ -52,7 +52,7 @@ from automates.model_assembly.networks import (
     GroundedFunctionNetwork
 )
 
-GENERATE_GRFN_2_2 = True
+GENERATE_GRFN_2_2 = False
 
 # flag deciding whether or not to use GE's interpretation of From Source 
 # when populating metadata information
@@ -410,6 +410,8 @@ def is_func_def_main(node) -> bool:
     return node.name.name == MAIN_FUNC_DEF_NAME
 
 def function_container_name(node) -> str:
+    # TODO: Maybe change this to take an FunctionDef instead of Name node?
+    # That might make more sense when calling it
     """
     Parameter: AnnCastNameNode
     Returns function container name in the form "name#id"
@@ -429,6 +431,16 @@ def func_def_ret_val_name(node) -> str:
     Used for the AnnCastCall's bot interface out
     """
     return f"{function_container_name(node.name)}_ret_val"
+
+def specialized_global_name(node, var_name) -> str:
+    """
+    Parameters: 
+        - node: a (AnnCast)FunctionDef 
+        - var_name: the variable name for the global
+    Returns the specialized global name for FunctionDef `func_def_node` 
+    """
+    return f"{function_container_name(node.name)}_{var_name}"
+
 
 def call_argument_name(node, arg_index: int) -> str:
     """
@@ -494,6 +506,13 @@ def parse_fullid(fullid: str) -> typing.Dict:
     assert(len(keys) == len(values))
 
     return dict(zip(keys, values))
+
+def lambda_var_from_fullid(fullid: str) -> str:
+    """
+    Return a suitable lambda variable name for variable with fullid `fullid`
+    """
+    parsed = parse_fullid(fullid)
+    return f"{parsed['var_name']}_{parsed['id']}"
 
 def var_name_from_fullid(fullid: str) -> str:
     """

--- a/automates/program_analysis/CAST2GrFN/ann_cast/container_scope_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/container_scope_pass.py
@@ -88,10 +88,9 @@ class ContainerScopePass:
                     container_node.used_globals.update(func_def.used_globals)
                     container_node.modified_globals.update(func_def.modified_globals)
                     container_node.globals_accessed_before_mod.update(func_def.globals_accessed_before_mod)
-                else:
-                    container_node.used_vars.update(func_def.used_globals)
-                    container_node.modified_vars.update(func_def.modified_globals)
-                    container_node.vars_accessed_before_mod.update(func_def.globals_accessed_before_mod)
+                container_node.used_vars.update(func_def.used_globals)
+                container_node.modified_vars.update(func_def.modified_globals)
+                container_node.vars_accessed_before_mod.update(func_def.globals_accessed_before_mod)
                 
     def add_container_data_to_expr(self, container, data):
         """
@@ -295,8 +294,9 @@ class ContainerScopePass:
                                                source_file_name=src_ref.source_file_name)
         node.grfn_con_src_ref = grfn_src_ref
         
-        # queue node to process globals through interfaces later
-        self.calls_to_process.append(node)
+        # queue node to process globals through interfaces later if we have the associated FunctionDef
+        if node.has_func_def:
+            self.calls_to_process.append(node)
 
         # # globals which are used by this Call's FunctionDef while be added to the Call's interface
         # # so, we need to propagate the use of these globals to enclosing containers

--- a/automates/program_analysis/CAST2GrFN/ann_cast/container_scope_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/container_scope_pass.py
@@ -31,7 +31,7 @@ class ContainerScopePass:
         # the container
         self.if_count = defaultdict(int)
         self.loop_count = defaultdict(int)
-        # dict mapping containter scope str to AnnCastNode
+        # dict mapping container scope str to AnnCastNode
         self.con_str_to_node = {}
         # dict mapping container scope str to cached Container Data
         self.con_str_to_con_data = {}
@@ -45,6 +45,9 @@ class ContainerScopePass:
 
         # add cached container data to container nodes
         self.add_container_data_to_nodes()
+ 
+        # save the dict mapping container scope to AnnCastNode
+        self.ann_cast.cont_scopestr_to_node = self.con_str_to_node
         print("Done")
 
     def next_if_scope(self, enclosing_con_scope):

--- a/automates/program_analysis/CAST2GrFN/ann_cast/container_scope_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/container_scope_pass.py
@@ -35,6 +35,7 @@ class ContainerScopePass:
         self.con_str_to_node = {}
         # dict mapping container scope str to cached Container Data
         self.con_str_to_con_data = {}
+        self.calls_to_process = list()
 
         for node in self.ann_cast.nodes:
             # assign_side is False at the start of our visitor
@@ -47,7 +48,9 @@ class ContainerScopePass:
         self.add_container_data_to_nodes()
  
         # save the dict mapping container scope to AnnCastNode
-        self.ann_cast.cont_scopestr_to_node = self.con_str_to_node
+        self.ann_cast.con_scopestr_to_node = self.con_str_to_node
+
+        self.propagate_globals_through_calls()
         print("Done")
 
     def next_if_scope(self, enclosing_con_scope):
@@ -62,6 +65,34 @@ class ContainerScopePass:
         self.loop_count[scopestr] += 1
         return enclosing_con_scope + [f"loop{count}"]
 
+    def propagate_globals_through_calls(self):
+        for call_node in self.calls_to_process:
+            func_def = self.ann_cast.func_def_node_from_id(call_node.func.id)
+
+            # propagate up used variables to enclosing container scopes
+            scopestr = ""
+            for index, name in enumerate(call_node.func.con_scope):
+                scopestr2 = CON_STR_SEP.join(call_node.func.con_scope[:index+1])
+                # add separator between container scope component names
+                if index != 0:
+                    scopestr += f"{CON_STR_SEP}"
+                scopestr += f"{name}"
+                assert(scopestr == scopestr2)
+
+                if scopestr == MODULE_SCOPE or not self.ann_cast.is_container(scopestr):
+                    continue
+
+                container_node = self.ann_cast.con_node_from_scopestr(scopestr)
+
+                if self.ann_cast.is_con_scopestr_func_def(scopestr):
+                    container_node.used_globals.update(func_def.used_globals)
+                    container_node.modified_globals.update(func_def.modified_globals)
+                    container_node.globals_accessed_before_mod.update(func_def.globals_accessed_before_mod)
+                else:
+                    container_node.used_vars.update(func_def.used_globals)
+                    container_node.modified_vars.update(func_def.modified_globals)
+                    container_node.vars_accessed_before_mod.update(func_def.globals_accessed_before_mod)
+                
     def add_container_data_to_expr(self, container, data):
         """
         Adds container data to `expr_*_vars` attributes of ModelIf and Loop nodes
@@ -214,13 +245,48 @@ class ContainerScopePass:
         if assign_side == AssignSide.RIGHT:
             node.has_ret_val = True
 
+        node.func.con_scope = enclosing_con_scope
         # if we are trying to generate GrFN 2.2 and this call has an associated
         # FunctionDef, make a GrFN 2.2 container for it
         if GENERATE_GRFN_2_2 and node.has_func_def:
             node.is_grfn_2_2 = True
             return self.visit_call_grfn_2_2(node, base_func_scopestr, enclosing_con_scope, assign_side)
-        
-        # otherwise, this Call should not be treated as a GrFN 2.2 call,
+
+        # Code that works, but does not allow recursive functions
+        # the children GrFN source ref for the call node is the src ref of the call's arguments
+#         args_src_ref = self.visit_node_list(node.arguments, base_func_scopestr, enclosing_con_scope, assign_side)
+# 
+#         # we make a func_def copy for both GrFN2.2 and non 2.2 Calls
+#         # for non 2.2 calls, the copied function def allows us to easily propagate 
+#         # globals to enclosing scopes which are needed for the Call's interfaces
+#         node.func_def_copy = copy.deepcopy(self.ann_cast.func_id_to_def[node.func.id])
+#         calling_scope = enclosing_con_scope + [call_container_name(node)]
+#         
+#         # for GrFN 2.2, the copied FunctionDef container will be a subcontainer of the container
+#         # for base_func_scopestr
+#         if node.is_grfn_2_2:
+#             # make a new id for the copy's Name node, and store in func_id_to_def
+#             node.func_def_copy.name.id = self.ann_cast.next_collapsed_id()
+#             self.ann_cast.func_id_to_def[node.func_def_copy.name.id] = node.func_def_copy
+#             self.visit_function_def(node.func_def_copy, base_func_scopestr, calling_scope, AssignSide.NEITHER)
+#         # for non GrFN 2.2 calls, we use calling_scopestr for base_func_scopestr 
+#         # this ensures no locals from the FunctionDef body are propagated up to enclosing scopes
+#         # instead only globals are propagated
+#         else:
+#             calling_scopestr = con_scope_to_str(calling_scope)
+#             self.visit_function_def(node.func_def_copy, calling_scopestr, calling_scope, AssignSide.NEITHER) 
+# 
+#             # For GrFN 2.2 calls, we store a GrfnContainerSrcRef for them
+#             grfn_src_ref = GrfnContainerSrcRef(None, None, None)
+#             if node.source_refs is not None:
+#                 src_ref = combine_source_refs(node.source_refs)
+#                 grfn_src_ref = GrfnContainerSrcRef(line_begin=src_ref.row_start, line_end=src_ref.row_end,
+#                                                    source_file_name=src_ref.source_file_name)
+#             node.grfn_con_src_ref = grfn_src_ref
+# 
+#         return args_src_ref
+#         
+        # otherwise, this Call should not be treated as a non GrFN 2.2 call,
         # so we store a GrfnContainerSrcRef for it
         grfn_src_ref = GrfnContainerSrcRef(None, None, None)
         if node.source_refs is not None:
@@ -228,15 +294,25 @@ class ContainerScopePass:
             grfn_src_ref = GrfnContainerSrcRef(line_begin=src_ref.row_start, line_end=src_ref.row_end,
                                                source_file_name=src_ref.source_file_name)
         node.grfn_con_src_ref = grfn_src_ref
+        
+        # queue node to process globals through interfaces later
+        self.calls_to_process.append(node)
 
-        node.func.con_scope = enclosing_con_scope
+        # # globals which are used by this Call's FunctionDef while be added to the Call's interface
+        # # so, we need to propagate the use of these globals to enclosing containers
+        # # to do this, we visit the body of the associated FunctionDef, and the propagation occurs in visit_name()
+        # func_def = self.ann_cast.func_def_node_from_id(node.func.id)
+        # call_con_scopestr = con_scope_to_str(enclosing_con_scope + [call_container_name(node)])
+        # # in this call to visit_node_list we use call_con_scope for base_func_scopestr 
+        # # this ensures no locals from the FunctionDef body are propagated up to enclosing scopes
+        # # instead only globals are propagated
+        # self.visit_node_list(func_def.body, call_con_scopestr, enclosing_con_scope, AssignSide.NEITHER)
         # For a call, we do not care about the arguments source refs
         return self.visit_node_list(node.arguments, base_func_scopestr, enclosing_con_scope, assign_side)
 
     def visit_call_grfn_2_2(self, node: AnnCastCall, base_func_scopestr, enclosing_con_scope, assign_side):
         assert isinstance(node.func, AnnCastName)
 
-        node.func.con_scope = enclosing_con_scope
         # the children GrFN source ref for the call node is the src ref of the call's arguments
         args_src_ref = self.visit_node_list(node.arguments, base_func_scopestr, enclosing_con_scope, assign_side)
 
@@ -413,10 +489,12 @@ class ContainerScopePass:
         #  2. this Name node is a global variable
         scopestr = ""
         for index, name in enumerate(enclosing_con_scope):
+            scopestr2 = CON_STR_SEP.join(enclosing_con_scope[:index+1])
             # add separator between container scope component names
             if index != 0:
                 scopestr += f"{CON_STR_SEP}"
             scopestr += f"{name}"
+            assert(scopestr == scopestr2)
             
             # if this Name node is a global, or if the scopestr extends base_func_scopestr
             # we will add the node to scopestr's container data

--- a/automates/program_analysis/CAST2GrFN/ann_cast/grfn_var_creation_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/grfn_var_creation_pass.py
@@ -3,6 +3,7 @@ from functools import singledispatchmethod
 
 from automates.program_analysis.CAST2GrFN.ann_cast.annotated_cast import *
 
+from automates.model_assembly.metadata import VariableCreationReason
 from automates.model_assembly.structures import (
     GenericIdentifier,
     VariableIdentifier,
@@ -159,7 +160,9 @@ class GrfnVarCreationPass:
             fullid = build_fullid(var_name, id, version, con_scopestr)
             self.ann_cast.store_grfn_var(fullid, grfn_var)
             # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.TOP_IFACE_INTRO)
+            # See comment above declaration for `FROM_SOURCE_FOR_GE` 
+            from_source = True if FROM_SOURCE_FOR_GE else False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.TOP_IFACE_INTRO)
             add_metadata_to_grfn_var(grfn_var, from_source_mdata)
 
             # alias VAR_INIT_VERSION expr variables
@@ -175,7 +178,9 @@ class GrfnVarCreationPass:
             fullid = build_fullid(var_name, id, version, con_scopestr)
             self.ann_cast.store_grfn_var(fullid, grfn_var)
             # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.BOT_IFACE_INTRO)
+            # See comment above declaration for `FROM_SOURCE_FOR_GE` 
+            from_source = True if FROM_SOURCE_FOR_GE else False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.BOT_IFACE_INTRO)
             add_metadata_to_grfn_var(grfn_var, from_source_mdata)
 
     def setup_loop_condition(self, node: AnnCastLoop):
@@ -206,7 +211,8 @@ class GrfnVarCreationPass:
         self.ann_cast.fullid_to_grfn_id[cond_fullid] = cond_var.uid
         self.ann_cast.grfn_id_to_grfn_var[cond_var.uid] = cond_var
         # create From Source metadata for the GrFN var
-        from_source_mdata = generate_from_source_metadata(False, CreationReason.COND_VAR)
+        from_source = False
+        from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.COND_VAR)
         add_metadata_to_grfn_var(cond_var, from_source_mdata)
 
         # cache condtiional variable
@@ -241,7 +247,8 @@ class GrfnVarCreationPass:
         self.ann_cast.fullid_to_grfn_id[cond_fullid] = cond_var.uid
         self.ann_cast.grfn_id_to_grfn_var[cond_var.uid] = cond_var
         # create From Source metadata for the GrFN var
-        from_source_mdata = generate_from_source_metadata(False, CreationReason.COND_VAR)
+        from_source = False
+        from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.COND_VAR)
         add_metadata_to_grfn_var(cond_var, from_source_mdata)
 
         # cache condtiional variable
@@ -303,7 +310,9 @@ class GrfnVarCreationPass:
             fullid = build_fullid(var_name, id, version, con_scopestr)
             self.ann_cast.store_grfn_var(fullid, grfn_var)
             # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.TOP_IFACE_INTRO)
+            # See comment above declaration for `FROM_SOURCE_FOR_GE` 
+            from_source = True if FROM_SOURCE_FOR_GE else False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.TOP_IFACE_INTRO)
             add_metadata_to_grfn_var(grfn_var, from_source_mdata)
 
             # alias VAR_INIT_VERSION expr variables
@@ -312,13 +321,16 @@ class GrfnVarCreationPass:
             expr_fullid = build_fullid(var_name, id, expr_version, expr_scopestr)
             self.ann_cast.alias_grfn_vars(expr_fullid, fullid)
 
-        # create version `LOOP_VAR_UPDATED_VERSION`  and `LOOP_VAR_EXIT_VERSION` 
+        # create version `LOOP_VAR_UPDATED_VERSION`  and `VAR_EXIT_VERSION` 
         # for modified variables
         for id, var_name in node.modified_vars.items():
             for version in [LOOP_VAR_UPDATED_VERSION, VAR_EXIT_VERSION]:
                 grfn_var = create_grfn_var(var_name, id, version, con_scopestr)
                 fullid = build_fullid(var_name, id, version, con_scopestr)
                 self.ann_cast.store_grfn_var(fullid, grfn_var)
+                # we intentionally do not add metadata to the GrFN variables here, since
+                # these variables will be aliased to other variables created from Name nodes
+                # and the metadata will be populated from those Name nodes
 
     def alias_loop_expr_highest_vers(self, node:AnnCastLoop):
         """

--- a/automates/program_analysis/CAST2GrFN/ann_cast/grfn_var_creation_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/grfn_var_creation_pass.py
@@ -76,7 +76,7 @@ class GrfnVarCreationPass:
         # NOTE: if we change to globals which are accessed before modification
         #       this loop should be changed as well
         # we alias globals which are used for the top interface
-        for id, var_name in node.top_interface_globals.items():
+        for id, var_name in node.top_interface_vars.items():
             body_fullid = build_fullid(var_name, id, version, func_con_scopestr)
             call_fullid = build_fullid(var_name, id, version, call_con_scopestr)
             # TODO: do we want this?

--- a/automates/program_analysis/CAST2GrFN/ann_cast/lambda_expression_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/lambda_expression_pass.py
@@ -4,7 +4,7 @@ from functools import singledispatchmethod
 from automates.program_analysis.CAST2GrFN.ann_cast.annotated_cast import *
 
 def lambda_for_grfn_assignment(grfn_assignment: GrfnAssignment, lambda_body: str) -> str:
-    var_names = map(var_name_from_fullid, grfn_assignment.inputs.keys())
+    var_names = map(lambda_var_from_fullid, grfn_assignment.inputs.keys())
 
     param_str = ", ".join(var_names)
     lambda_expr = f"lambda {param_str}: {lambda_body}"  
@@ -12,7 +12,7 @@ def lambda_for_grfn_assignment(grfn_assignment: GrfnAssignment, lambda_body: str
     return lambda_expr
 
 def lambda_for_condition(condition_in: typing.Dict, lambda_body: str) -> str:
-    var_names = map(var_name_from_fullid, condition_in.values())
+    var_names = map(lambda_var_from_fullid, condition_in.values())
 
     param_str = ", ".join(var_names)
     lambda_expr = f"lambda {param_str}: {lambda_body}"
@@ -29,7 +29,7 @@ def lambda_for_decision(condition_fullid: str, decision_in: typing.Dict) -> str:
     """
     if len(decision_in) == 0:
         return f"lambda: None"
-    cond_name = var_name_from_fullid(condition_fullid)
+    cond_name = lambda_var_from_fullid(condition_fullid)
 
     lambda_body = ""
 
@@ -37,9 +37,9 @@ def lambda_for_decision(condition_fullid: str, decision_in: typing.Dict) -> str:
     else_names = []
     for dec in decision_in.values():
         if_fullid = dec[IFBODY]
-        if_names.append(var_name_from_fullid(if_fullid) + "_if")
+        if_names.append(lambda_var_from_fullid(if_fullid) + "_if")
         else_fullid = dec[ELSEBODY]
-        else_names.append(var_name_from_fullid(else_fullid) + "_else")
+        else_names.append(lambda_var_from_fullid(else_fullid) + "_else")
 
     if_names_str = ", ".join(if_names)
     else_names_str = ", ".join(else_names)
@@ -58,8 +58,7 @@ def lambda_for_interface(interface_in: typing.Dict) -> str:
     if len(interface_in) == 0:
         return "lambda: None"
 
-    get_name = lambda fullid: parse_fullid(fullid)["var_name"]
-    var_names = map(get_name, interface_in.values())
+    var_names = map(lambda_var_from_fullid, interface_in.values())
     param_str = ", ".join(var_names)
 
     lambda_expr = f"lambda {param_str}: ({param_str})"  
@@ -78,9 +77,9 @@ def lambda_for_loop_top_interface(top_interface_initial: typing.Dict, top_interf
     The `use_initial` value comes from the internal state of the LoopTopInterface during execution.
     """
 
-    init_name = lambda fullid: var_name_from_fullid(fullid) + "_init"
+    init_name = lambda fullid: lambda_var_from_fullid(fullid) + "_init"
     init_names = map(init_name, top_interface_initial.values())
-    updt_name = lambda fullid: var_name_from_fullid(fullid) + "_update"
+    updt_name = lambda fullid: lambda_var_from_fullid(fullid) + "_update"
     updt_names = map(updt_name, top_interface_updated.values())
 
     # NOTE: the lengths of top_interface_initial and top_interface_updated may not be the same
@@ -111,7 +110,7 @@ def lambda_for_loop_top_interface(top_interface_initial: typing.Dict, top_interf
     return lambda_expr
 
 def lambda_for_loop_condition(condition_in, lambda_body):
-    var_names = map(var_name_from_fullid, condition_in.values())
+    var_names = map(lambda_var_from_fullid, condition_in.values())
 
     param_str = ", ".join(var_names)
     lambda_expr = f"lambda {param_str}: {lambda_body}"
@@ -261,7 +260,7 @@ class LambdaExpressionPass:
         if node.has_ret_val:
             assert(len(node.out_ret_val) == 1)
             ret_val_fullid = list(node.out_ret_val.values())[0]
-            node.expr_str = var_name_from_fullid(ret_val_fullid)
+            node.expr_str = lambda_var_from_fullid(ret_val_fullid)
         
         return node.expr_str
 

--- a/automates/program_analysis/CAST2GrFN/ann_cast/to_grfn_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/to_grfn_pass.py
@@ -426,6 +426,9 @@ class ToGrfnPass:
         self.visit(node.expr, subgraph)
 
     def visit_function_def_copy(self, node: AnnCastFunctionDef, subgraph: GrFNSubgraph):
+        for dummy_assignment in node.dummy_grfn_assignments:
+            self.visit_grfn_assignment(dummy_assignment, subgraph)
+
         self.visit_node_list(node.func_args, subgraph)
         self.visit_node_list(node.body, subgraph)
 
@@ -467,6 +470,10 @@ class ToGrfnPass:
             # add interface node and outputs to subraph
             subgraph.nodes.append(top_interface)
             subgraph.nodes.extend(outputs)
+        
+        # visit dummy assignments before body
+        for dummy_assignment in node.dummy_grfn_assignments:
+            self.visit_grfn_assignment(dummy_assignment, subgraph)
 
         # visit body
         self.visit_node_list(node.body, subgraph)

--- a/automates/program_analysis/CAST2GrFN/ann_cast/to_grfn_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/to_grfn_pass.py
@@ -22,6 +22,7 @@ from automates.model_assembly.networks import (
     GrFNLoopSubgraph,
     HyperEdge,
     LambdaNode,
+    LoopTopInterface,
     VariableNode
 )
 
@@ -67,10 +68,10 @@ class ToGrfnPass:
     def create_interface_node(self, lambda_expr):
         # we should never create an interface node if we have an empty lambda expr
         assert(len(lambda_expr) > 0)
-        # TODO: correct values for thes
-        lambda_uuid = str(uuid.uuid4())[:5]
+        lambda_uuid = str(uuid.uuid4())
         lambda_str = lambda_expr
         lambda_func = load_lambda_function(lambda_str)
+        # FUTURE: decide on metadata for interface nodes
         lambda_metadata = []
         lambda_type = LambdaType.INTERFACE
 
@@ -85,14 +86,14 @@ class ToGrfnPass:
     def create_loop_top_interface(self, lambda_expr):
         # we should never create an interface node if we have an empty lambda expr
         assert(len(lambda_expr) > 0)
-        # TODO: correct values for these
         lambda_uuid = str(uuid.uuid4())
         lambda_str = lambda_expr
         lambda_func = load_lambda_function(lambda_str)
+        # FUTURE: decide on metadata for interface nodes
         lambda_metadata = []
         lambda_type = LambdaType.LOOP_TOP_INTERFACE
 
-        interface_node = LambdaNode(lambda_uuid, lambda_type,
+        interface_node = LoopTopInterface(lambda_uuid, lambda_type,
                                      lambda_str, lambda_func, lambda_metadata)
 
         return interface_node
@@ -117,10 +118,10 @@ class ToGrfnPass:
         self.hyper_edges.append(HyperEdge(inputs, lambda_node, outputs))
 
     def create_condition_node(self, condition_in, condition_out, lambda_expr,  subgraph: GrFNSubgraph):
-        # TODO: correct values for these
         lambda_uuid = str(uuid.uuid4())
         lambda_str = lambda_expr
         lambda_func = load_lambda_function(lambda_str)
+        # FUTURE: decide on metadata for condition nodes
         lambda_metadata = []
         lambda_type = LambdaType.CONDITION
 
@@ -151,6 +152,7 @@ class ToGrfnPass:
         lambda_uuid = str(uuid.uuid4())
         lambda_str = lambda_expr
         lambda_func = load_lambda_function(lambda_str)
+        # FUTURE: decide on metadata for decision nodes
         lambda_metadata = []
         lambda_type = LambdaType.DECISION
 

--- a/automates/program_analysis/CAST2GrFN/ann_cast/variable_version_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/variable_version_pass.py
@@ -738,6 +738,32 @@ class VariableVersionPass:
         # add globals to exterior interfaces
         # top interface globals are globals which are accessed before modification
         node.top_interface_globals = func_def.used_globals
+
+        # TODO: Figure this out 
+        # first, we need to propagate up globals
+        # due to GrFN 2.2 FunctionDef copying, we need to also propagate up the
+        # globals accessed before modification and modified globals to 
+        # scopes higher than base_func_scopestr
+#         scopestr = ""
+#         for index, name in enumerate(node.func.con_scope):
+#             # add separator between container scope component names
+#             if index != 0:
+#                 scopestr += f"{CON_STR_SEP}"
+#                 scopestr += f"{name}"
+#             # TODO: store dict mapping all container scope strs to container nodes
+#             # currently, we only do this for function defs
+#             # otherwise, add to correct globals tracking dict
+#             func_node = self.ann_cast.func_def_node_from_scopestr(scopestr)
+# 
+#             if node.version == VAR_INIT_VERSION:  # only occurs on RHS
+#             func_node.globals_accessed_before_mod[node.id] = node.name
+#             # if we are assigning to the global, then it is modified
+#             elif assign_lhs:
+#             func_node.modified_globals[node.id] = node.name
+#             # no matter what, add to used_globals dict
+#             func_node.used_globals[node.id] = node.name
+
+
         # add global variables to top_interface_in
         self.populate_interface(calling_scopestr, node.top_interface_globals, node.top_interface_in)
         # the bot interface globals are all modified globals

--- a/automates/program_analysis/CAST2GrFN/ann_cast/variable_version_pass.py
+++ b/automates/program_analysis/CAST2GrFN/ann_cast/variable_version_pass.py
@@ -2,6 +2,7 @@ import typing
 from functools import singledispatchmethod
 
 from automates.model_assembly.networks import load_lambda_function
+from automates.model_assembly.metadata import VariableCreationReason
 
 from automates.program_analysis.CAST2GrFN.ann_cast.annotated_cast import *
 
@@ -80,7 +81,9 @@ class VariableVersionPass:
         """
         for fullid in interface_vars.values():
             grfn_var = self.ann_cast.get_grfn_var(fullid)
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.BOT_IFACE_INTRO)
+            # See comment above declaration for `FROM_SOURCE_FOR_GE` 
+            from_source = True if FROM_SOURCE_FOR_GE else False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.BOT_IFACE_INTRO)
             add_metadata_to_grfn_var(grfn_var, from_source_mdata=from_source_mdata)
 
 
@@ -118,7 +121,7 @@ class VariableVersionPass:
         new_version = self.con_scope_to_highest_var_vers[con_scopestr][id]
         new_fullid = build_fullid(var_name, id, new_version, con_scopestr)
         grfn_var = self.ann_cast.get_grfn_var(new_fullid)
-        from_source_mdata = generate_from_source_metadata(False, CreationReason.DUMMY_ASSIGN)
+        from_source_mdata = generate_from_source_metadata(False, VariableCreationReason.DUMMY_ASSIGN)
         add_metadata_to_grfn_var(grfn_var, from_source_mdata)
 
         # create a literal GrFN assignment for this dummy assignment
@@ -268,7 +271,8 @@ class VariableVersionPass:
             # store arg_fullid
             node.arg_index_to_fullid[i] = arg_fullid
             # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.FUNC_ARG)
+            from_source = False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.FUNC_ARG)
             add_metadata_to_grfn_var(arg_grfn_var, from_source_mdata)
 
             param_grfn_var = create_grfn_var(param_name, id, version, param_con_scopestr)
@@ -307,7 +311,8 @@ class VariableVersionPass:
         in_fullid = build_fullid(var_name, id, version, func_scopestr)
         self.ann_cast.store_grfn_var(in_fullid, in_ret_val)
         # create From Source metadata for the GrFN var
-        from_source_mdata = generate_from_source_metadata(False, CreationReason.FUNC_RET_VAL)
+        from_source = False
+        from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.FUNC_RET_VAL)
         add_metadata_to_grfn_var(in_ret_val, from_source_mdata)
 
 
@@ -373,8 +378,9 @@ class VariableVersionPass:
             init_global = create_grfn_var(var_name, id, version, func_scopestr)
             self.ann_cast.store_grfn_var(init_fullid, init_global)
             node.top_interface_out[id] = init_fullid
-            # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.TOP_IFACE_INTRO)
+            # See comment above declaration for `FROM_SOURCE_FOR_GE` 
+            from_source = True if FROM_SOURCE_FOR_GE else False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.TOP_IFACE_INTRO)
             add_metadata_to_grfn_var(init_global, from_source_mdata)
     
         # we do not create the GrFN VariableNode for the highest version global
@@ -442,7 +448,7 @@ class VariableVersionPass:
     #         self.ann_cast.store_grfn_var(in_fullid, in_global)
     #         node.top_interface_in[id] = in_fullid
     #         # create From Source metadata for the GrFN var
-    #         from_source_mdata = generate_from_source_metadata(False, CreationReason.DUP_GLOBAL)
+    #         from_source_mdata = generate_from_source_metadata(False, VariableCreationReason.DUP_GLOBAL)
     #         add_metadata_to_grfn_var(in_global, from_source_mdata)
     #         # interior specialized top global
     #         out_fullid = build_fullid(var_name, id, version, func_scopestr)
@@ -450,7 +456,7 @@ class VariableVersionPass:
     #         self.ann_cast.store_grfn_var(out_fullid, out_global)
     #         node.top_interface_out[id] = out_fullid
     #         # create From Source metadata for the GrFN var
-    #         from_source_mdata = generate_from_source_metadata(False, CreationReason.TOP_IFACE_INTRO)
+    #         from_source_mdata = generate_from_source_metadata(False, VariableCreationReason.TOP_IFACE_INTRO)
     #         add_metadata_to_grfn_var(in_global, from_source_mdata)
     # 
     #     # create specialized globals for bot interface
@@ -513,7 +519,8 @@ class VariableVersionPass:
             # store arg_fullid
             node.arg_index_to_fullid[i] = arg_fullid
             # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.FUNC_ARG)
+            from_source = False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.FUNC_ARG)
             add_metadata_to_grfn_var(arg_grfn_var, from_source_mdata)
 
             param_grfn_var = create_grfn_var(param_name, id, version, param_con_scopestr)
@@ -566,7 +573,8 @@ class VariableVersionPass:
             # store arg_fullid
             node.arg_index_to_fullid[i] = arg_fullid
             # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.FUNC_ARG)
+            from_source = False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.FUNC_ARG)
             add_metadata_to_grfn_var(arg_grfn_var, from_source_mdata)
 
             param_grfn_var = create_grfn_var(param_name, id, version, param_con_scopestr)
@@ -605,7 +613,8 @@ class VariableVersionPass:
         in_fullid = build_fullid(var_name, id, version, call_con_scopestr)
         self.ann_cast.store_grfn_var(in_fullid, in_ret_val)
         # create From Source metadata for the GrFN var
-        from_source_mdata = generate_from_source_metadata(False, CreationReason.FUNC_RET_VAL)
+        from_source = False
+        from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.FUNC_RET_VAL)
         add_metadata_to_grfn_var(in_ret_val, from_source_mdata)
 
         # exterior container scope
@@ -661,7 +670,8 @@ class VariableVersionPass:
             # store arg_fullid
             node.arg_index_to_fullid[i] = arg_fullid
             # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.FUNC_ARG)
+            from_source = False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.FUNC_ARG)
             add_metadata_to_grfn_var(arg_grfn_var, from_source_mdata)
 
             param_grfn_var = create_grfn_var(param_name, id, version, param_con_scopestr)
@@ -702,7 +712,8 @@ class VariableVersionPass:
         in_fullid = build_fullid(var_name, id, version, call_con_scopestr)
         self.ann_cast.store_grfn_var(in_fullid, in_ret_val)
         # create From Source metadata for the GrFN var
-        from_source_mdata = generate_from_source_metadata(False, CreationReason.FUNC_RET_VAL)
+        from_source = False
+        from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.FUNC_RET_VAL)
         add_metadata_to_grfn_var(in_ret_val, from_source_mdata)
 
         # exterior container scope
@@ -771,8 +782,9 @@ class VariableVersionPass:
             call_init_global = create_grfn_var(var_name, id, version, call_con_scopestr)
             self.ann_cast.store_grfn_var(call_init_fullid, call_init_global)
             node.top_interface_out[id] = call_init_fullid
-            # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.TOP_IFACE_INTRO)
+            # See comment above declaration for `FROM_SOURCE_FOR_GE` 
+            from_source = True if FROM_SOURCE_FOR_GE else False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.TOP_IFACE_INTRO)
             add_metadata_to_grfn_var(call_init_global, from_source_mdata)
 
             # alias the func copies init version
@@ -785,6 +797,10 @@ class VariableVersionPass:
             exit_global = create_grfn_var(var_name, id, version, call_con_scopestr)
             self.ann_cast.store_grfn_var(exit_fullid, exit_global)
             node.bot_interface_in[id] = exit_fullid
+            # we intentionally do not add metadata to the GrFN variable here, since
+            # the highest version from the copied FunctionDef will be aliased to this
+            # variable, and the metadata for this GrFN variable will be populated from 
+            # that highest version
 
         print("After adding globals for GrFN 2.2 call ():")
         print(f"\ttop_interface_in = {node.top_interface_in}")
@@ -858,8 +874,9 @@ class VariableVersionPass:
             init_global = create_grfn_var(var_name, id, version, call_con_scopestr)
             self.ann_cast.store_grfn_var(init_fullid, init_global)
             node.top_interface_out[id] = init_fullid
-            # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.TOP_IFACE_INTRO)
+            # See comment above declaration for `FROM_SOURCE_FOR_GE` 
+            from_source = True if FROM_SOURCE_FOR_GE else False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.TOP_IFACE_INTRO)
             add_metadata_to_grfn_var(init_global, from_source_mdata)
     
         for id, var_name in node.bot_interface_vars.items():
@@ -868,8 +885,9 @@ class VariableVersionPass:
             exit_global = create_grfn_var(var_name, id, version, call_con_scopestr)
             self.ann_cast.store_grfn_var(exit_fullid, exit_global)
             node.bot_interface_in[id] = exit_fullid
-            # create From Source metadata for the GrFN var
-            from_source_mdata = generate_from_source_metadata(False, CreationReason.BOT_IFACE_INTRO)
+            # See comment above declaration for `FROM_SOURCE_FOR_GE` 
+            from_source = True if FROM_SOURCE_FOR_GE else False
+            from_source_mdata = generate_from_source_metadata(from_source, VariableCreationReason.BOT_IFACE_INTRO)
             add_metadata_to_grfn_var(exit_global, from_source_mdata)
 
         print("After adding globals for GrFN 2.3 call ():")

--- a/scripts/program_analysis/gcc_to_agraph.py
+++ b/scripts/program_analysis/gcc_to_agraph.py
@@ -1,0 +1,182 @@
+import sys
+import json
+import html
+from typing import Dict
+from collections import defaultdict, namedtuple
+
+import pygraphviz as pgv
+from pygraphviz import AGraph
+
+OPS_TO_STR = {
+    "mult_expr": "*",
+    "plus_expr": "+",
+    "minus_expr": "-",
+    "ge_expr": ">=",
+    "gt_expr": ">",
+    "le_expr": "<=",
+    "lt_expr": "<",
+    "rdiv_expr": "/",
+    "trunc_div_expr": "/", 
+    "eq_expr": "==",
+    "ne_expr": "!=",
+    "negate_expr": "-",
+    "lshift_expr": "<<",
+    "rshift_expr": ">>",
+    "bit_xor_expr": "^",
+    "bit_and_expr": "&",
+    "bit_ior_expr": "|",
+    "bit_not_expr": "~",
+    "logical_or": "||",
+    "logical_and": "&&",
+    "trunc_mod_expr": "%", 
+}
+
+Edge = namedtuple("Edge", ["src", "tgt", "flags"])
+
+FALLTHROUGH_FLAG = 2**0
+TRUE_FLAG = 2**8
+FALSE_FLAG = 2**9
+
+edge_colors = {}
+edge_colors[FALLTHROUGH_FLAG] = "grey"
+edge_colors[TRUE_FLAG] = "green"
+edge_colors[FALSE_FLAG] = "red"
+
+EDGE_FLAGS = [FALLTHROUGH_FLAG, TRUE_FLAG, FALSE_FLAG]
+
+
+def json_to_agraph_pdf(gcc_ast):
+    input_file = gcc_ast["mainInputFilename"]
+    input_file_stripped = input_file.split("/")[-1]
+    functions = gcc_ast["functions"]
+    types = gcc_ast["recordTypes"]
+    global_variables = gcc_ast["globalVariables"]
+
+    G = pgv.AGraph(directed=True)
+
+    for f in functions:
+        add_function_subgraph(f, G)
+
+    G.graph_attr.update(
+        {"dpi": 227, "fontsize": 20, "fontname": "Menlo", "rankdir": "TB"}
+    )
+    G.node_attr.update({"fontname": "Menlo"})
+
+    G.draw(f"{input_file_stripped}--gcc_ast-graph.pdf", prog="dot")
+
+def add_basic_block_node(bb: Dict, name: str, subgraph: AGraph):
+    """Parameters:
+        bb: the dict storing the basic block data from the json output of gcc plugin
+        name: the name for the basic block node
+        subgraph: the graph to add the basic block node to
+        Adds an HTML node to `subgraph` with the statements from `bb`
+    """
+    label = f"<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\">"
+    label += f"<tr><td><b>{name}</b></td></tr>"
+    for index, stmt in enumerate(bb["statements"]):
+        type = stmt["type"]
+        l_start = stmt["line_start"] if "line_start" in stmt else -1
+        c_start = stmt["col_start"] if "col_start" in stmt else -1
+        loc = f"{l_start}:{c_start}"
+
+        if type == "conditional":
+            stmt_str = parse_conditional_stmt(stmt)
+            # have to convert stmt_str to valid HTML
+            label += f"<tr><td>{html.escape(stmt_str)}</td></tr>"
+        # default label
+        else:
+            label += f"<tr><td>{type} at {loc}</td></tr>"
+
+
+    label += "</table>>"
+    print(label)
+
+    subgraph.add_node(name, label=label, shape="plaintext")
+
+def add_function_subgraph(function: Dict, graph: AGraph):
+    """
+    Parameters:
+        function: the dict storing the function data from the json output of gcc plugin
+        graph: the graph to add the function cluster to
+        Adds a function cluster/subraph consisting of all the basic blocks
+        in the `function` dict
+    """
+    func_name = function["name"]
+    bb_label = lambda index: f"{func_name}.BB{index}"
+    F = graph.add_subgraph(name=f"cluster_{func_name}", label=func_name, 
+            style="bold, rounded", rankdir="LR")
+
+    # TODO: verify that index 0 basic block is the entry point and 
+    # index 1 basic block is the exit point
+    # entry_index = 0
+    # exit_index = 1
+
+    edges_to_add = defaultdict(list)
+
+    for bb in function["basicBlocks"]:
+        # special case nodes for entry and exit
+        # if bb["index"] == entry_index:
+        #     F.add_node(f"{func_name}.Entry")
+        # elif bb["index"] == exit_index:
+        #     F.add_node(f"{func_name}.Exit")
+        bb_name = bb_label(bb["index"])
+        add_basic_block_node(bb, bb_name, F)
+
+        for e in bb["edges"]:
+            src = bb_label(e["source"])
+            tgt = bb_label(e["target"])
+            edge = Edge(src=src, tgt=tgt, flags=e["flags"])
+            edges_to_add[src].append(edge)
+
+    for src in edges_to_add:
+        for edge in edges_to_add[src]:
+            color = "black"
+            if edge.flags in EDGE_FLAGS:
+                color = edge_colors[edge.flags]
+
+            F.add_edge(edge.src, edge.tgt, color=color)
+
+def parse_conditional_stmt(stmt: Dict):
+    """
+    Parameters:
+        `stmt` 'conditional' type statement from a basic block
+        obtained from gcc plugin generated json
+    Returns:
+            A str representing a suitable label for the conditional statement
+    """
+    op = OPS_TO_STR[stmt["operator"]]
+    lhs = parse_operand(stmt["operands"][0])
+    rhs = parse_operand(stmt["operands"][1])
+
+    if len(stmt["operands"]) > 2:
+        print("WARNING: parse_conditional_stmt() more than two operands!")
+
+    return f"{lhs} {op} {rhs}"
+
+
+def parse_operand(operand: Dict):
+    """
+    Parameter:
+        `operand` is a operand dict obtained from gcc plugin generated json
+    Returns: 
+        A str representing the operand
+    """
+    # TODO: This only parses a couple things
+    if "name" in operand:
+        return operand["name"]
+    elif "value" in operand:
+        return operand["value"]
+    else:
+        return "Operand"
+
+
+
+def main():
+    json_file = sys.argv[1]
+    print(f"Loaded json_file: {json_file}")
+    ast_json = json.load(open(json_file))
+
+    json_to_agraph_pdf(ast_json)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Implemented a flag `FROM_SOURCE_FOR_GE` which will change the from source metadata for VariableNodes to be as they requested
- Specialized globals are now used for 2.3 FunctionDefs
- Resolved a GrFN generation issue with Interface nodes that are neither grandparents nor have a grandparent
- Added variable ids to variables in lambda expressions to fix an issue with variable name collisions
- Changed loop container's top interface to be of type `LoopTopInterface`.  This will be helpful later during execution implementation
- Added in dummy assignments to FunctionDef's when those variables are expected to propagate through a container's top interface.  This resolves issues for CAST generated from Python due to dynamic variable creation e.g.
```python
def func():
    z = 3
    if z == 3:
        y = 5
    else:
        y = 7
```
The AnnCast pipeline expects `y` to enter through the If container's top interface, so we add a dummy assignment `y = None` at the top of `func()`

