### PR TITLE
Claytonm/requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ flask_wtf==0.14.3
 future==0.18.2
 matplotlib==3.3.3
 networkx==2.4
-nltk==3.4.5
-notebook==6.4.1
-numpy==1.18.2
+nltk==3.6.6
+notebook==6.4.10
+numpy==1.21
 pandas==1.2.3
 plotly==4.5.4
 pygraphviz==1.5

--- a/scripts/code_summarization/README.md
+++ b/scripts/code_summarization/README.md
@@ -1,2 +1,8 @@
 # code-summarization
 Neural machine translation method to generate descriptive summaries of Python source code functions
+
+## NOTE 2022-05-21
+This code has not been check in some time.
+It originally worked with nltk 3.4.5, which has since been found to have a number of security issues.
+We are bumping nltk in automates requirements.txt to require nltk >= 3.6.6.
+If this code is to be used in the future, it may need updating to work with nltk again.


### PR DESCRIPTION
Hi @titomeister : This has been a task I have meant to get to for a long time. Dependabot has identified several of our requirements.txt module versions that are at older versions that should be increased. This PR makes the following changes to requirements.txt:

- notebook from 6.4.1 to 6.5.10
- numpy from 1.18.2 to 1.21
- nltk from 3.4.5 to 3.6.6

nltk is only used by scripts/code_summarization , which is older code created by Paul Hein. I've added to the README here that this code may need to be verified, but I'm ok bumping without testing for now.

I'm pretty sure both of the notebook and numpy changes will not cause problems, but could you please run our PA pipeline and its tests to verify?
